### PR TITLE
Introduce support for `hanami generate part`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ end
 gem "dry-files", require: false, git: "https://github.com/dry-rb/dry-files.git", branch: "main"
 gem "dry-logger", require: false, git: "https://github.com/dry-rb/dry-logger.git", branch: "main"
 gem "hanami-utils", require: false, git: "https://github.com/hanami/utils.git", branch: "main"
-gem "hanami-cli", require: false, git: "https://github.com/hanami/cli.git", branch: "main"
+gem "hanami-cli", require: false, git: "https://github.com/hanami/cli.git", branch: "feature/view-part-generator"
 gem "hanami", require: false, git: "https://github.com/hanami/hanami.git", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ end
 gem "dry-files", require: false, git: "https://github.com/dry-rb/dry-files.git", branch: "main"
 gem "dry-logger", require: false, git: "https://github.com/dry-rb/dry-logger.git", branch: "main"
 gem "hanami-utils", require: false, git: "https://github.com/hanami/utils.git", branch: "main"
-gem "hanami-cli", require: false, git: "https://github.com/hanami/cli.git", branch: "feature/view-part-generator"
+gem "hanami-cli", require: false, git: "https://github.com/hanami/cli.git", branch: "main"
 gem "hanami", require: false, git: "https://github.com/hanami/hanami.git", branch: "main"

--- a/lib/hanami/rspec.rb
+++ b/lib/hanami/rspec.rb
@@ -35,6 +35,7 @@ module Hanami
       Hanami::CLI.after "install", Commands::Install
       Hanami::CLI.after "generate slice", Commands::Generate::Slice
       Hanami::CLI.after "generate action", Commands::Generate::Action
+      Hanami::CLI.after "generate part", Commands::Generate::Part
     end
   end
 end

--- a/lib/hanami/rspec/commands.rb
+++ b/lib/hanami/rspec/commands.rb
@@ -103,7 +103,7 @@ module Hanami
         # @since 2.1.0
         # @api private
         class Part < Hanami::CLI::Commands::App::Command
-          # @since 2.0.0
+          # @since 2.1.0
           # @api private
           def call(options, **)
             # FIXME: dry-cli kwargs aren't correctly forwarded in Ruby 3

--- a/lib/hanami/rspec/commands.rb
+++ b/lib/hanami/rspec/commands.rb
@@ -99,6 +99,21 @@ module Hanami
             generator.call(app.namespace, slice, controller, action)
           end
         end
+
+        # @since 2.1.0
+        # @api private
+        class Part < Hanami::CLI::Commands::App::Command
+          # @since 2.0.0
+          # @api private
+          def call(options, **)
+            # FIXME: dry-cli kwargs aren't correctly forwarded in Ruby 3
+            slice = inflector.underscore(Shellwords.shellescape(options[:slice])) if options[:slice]
+            name = inflector.underscore(Shellwords.shellescape(options[:name]))
+
+            generator = Generators::Part.new(fs: fs, inflector: inflector)
+            generator.call(app.namespace, slice, name)
+          end
+        end
       end
     end
   end

--- a/lib/hanami/rspec/generators/part.rb
+++ b/lib/hanami/rspec/generators/part.rb
@@ -19,19 +19,60 @@ module Hanami
         # @api private
         def call(app, slice, name, context: Hanami::CLI::Generators::App::PartContext.new(inflector, app, slice, name))
           if slice
-            fs.write(
-              "spec/slices/#{slice}/views/parts/#{context.underscored_name}_spec.rb",
-              t("part_slice_spec.erb", context)
-            )
+            generate_for_slice(slice, context)
           else
-            fs.write(
-              "spec/views/parts/#{context.underscored_name}_spec.rb",
-              t("part_spec.erb", context)
-            )
+            generate_for_app(context)
           end
         end
 
         private
+
+        # @since 2.1.0
+        # @api private
+        def generate_for_slice(slice, context)
+          generate_base_part_for_app(context)
+          generate_base_part_for_slice(context, slice)
+
+          fs.write(
+            "spec/slices/#{slice}/views/parts/#{context.underscored_name}_spec.rb",
+            t("part_slice_spec.erb", context)
+          )
+        end
+
+        # @since 2.1.0
+        # @api private
+        def generate_for_app(context)
+          generate_base_part_for_app(context)
+
+          fs.write(
+            "spec/views/parts/#{context.underscored_name}_spec.rb",
+            t("part_spec.erb", context)
+          )
+        end
+
+        # @since 2.1.0
+        # @api private
+        def generate_base_part_for_app(context)
+          path = fs.join("spec", "views", "part_spec.rb")
+          return if fs.exist?(path)
+
+          fs.write(
+            path,
+            t("part_base_spec.erb", context)
+          )
+        end
+
+        # @since 2.1.0
+        # @api private
+        def generate_base_part_for_slice(context, slice)
+          path = "spec/slices/#{slice}/views/part_spec.rb"
+          return if fs.exist?(path)
+
+          fs.write(
+            path,
+            t("part_slice_base_spec.erb", context)
+          )
+        end
 
         # @since 2.1.0
         # @api private

--- a/lib/hanami/rspec/generators/part.rb
+++ b/lib/hanami/rspec/generators/part.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "erb"
+
+module Hanami
+  module RSpec
+    module Generators
+      # @since 2.1.0
+      # @api private
+      class Part
+        # @since 2.1.0
+        # @api private
+        def initialize(fs:, inflector:)
+          @fs = fs
+          @inflector = inflector
+        end
+
+        # @since 2.1.0
+        # @api private
+        def call(app, slice, name, context: Hanami::CLI::Generators::App::PartContext.new(inflector, app, slice, name))
+          if slice
+            fs.write(
+              "spec/slices/#{slice}/views/parts/#{context.underscored_name}_spec.rb",
+              t("part_slice_spec.erb", context)
+            )
+          else
+            fs.write(
+              "spec/views/parts/#{context.underscored_name}_spec.rb",
+              t("part_spec.erb", context)
+            )
+          end
+        end
+
+        private
+
+        attr_reader :fs
+
+        attr_reader :inflector
+
+        # @api private
+        # @param controller [Array<String>]
+        def controller_directory(controller)
+          fs.join(controller)
+        end
+
+        def template(path, context)
+          require "erb"
+
+          ERB.new(
+            File.read(__dir__ + "/part/#{path}")
+          ).result(context.ctx)
+        end
+
+        alias_method :t, :template
+      end
+    end
+  end
+end

--- a/lib/hanami/rspec/generators/part.rb
+++ b/lib/hanami/rspec/generators/part.rb
@@ -33,16 +33,16 @@ module Hanami
 
         private
 
+        # @since 2.1.0
+        # @api private
         attr_reader :fs
 
+        # @since 2.1.0
+        # @api private
         attr_reader :inflector
 
+        # @since 2.1.0
         # @api private
-        # @param controller [Array<String>]
-        def controller_directory(controller)
-          fs.join(controller)
-        end
-
         def template(path, context)
           require "erb"
 
@@ -51,6 +51,8 @@ module Hanami
           ).result(context.ctx)
         end
 
+        # @since 2.1.0
+        # @api private
         alias_method :t, :template
       end
     end

--- a/lib/hanami/rspec/generators/part.rb
+++ b/lib/hanami/rspec/generators/part.rb
@@ -88,7 +88,8 @@ module Hanami
           require "erb"
 
           ERB.new(
-            File.read(__dir__ + "/part/#{path}")
+            File.read(__dir__ + "/part/#{path}"),
+            trim_mode: "-"
           ).result(context.ctx)
         end
 

--- a/lib/hanami/rspec/generators/part/part_base_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_base_spec.erb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_app_name %>::Views::Part do
+<%- if ruby_implicity_keyword_argument? -%>
+  subject { described_class.new(value:) }
+<%- else -%>
+  subject { described_class.new(value: value) }
+<%- end -%>
+  let(:value) { double("value") }
+
   it "works" do
     expect(subject).to be_kind_of(described_class)
   end

--- a/lib/hanami/rspec/generators/part/part_base_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_base_spec.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe <%= camelized_app_name %>::Views::Part do
+  it "works" do
+    expect(subject).to be_kind_of(described_class)
+  end
+end

--- a/lib/hanami/rspec/generators/part/part_base_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_base_spec.erb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_app_name %>::Views::Part do
-<%- if ruby_implicity_keyword_argument? -%>
+<%- if ruby_omit_hash_values? -%>
   subject { described_class.new(value:) }
 <%- else -%>
   subject { described_class.new(value: value) }

--- a/lib/hanami/rspec/generators/part/part_slice_base_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_slice_base_spec.erb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_slice_name %>::Views::Part do
+<%- if ruby_implicity_keyword_argument? -%>
+  subject { described_class.new(value:) }
+<%- else -%>
+  subject { described_class.new(value: value) }
+<%- end -%>
+  let(:value) { double("value") }
+
   it "works" do
     expect(subject).to be_kind_of(described_class)
   end

--- a/lib/hanami/rspec/generators/part/part_slice_base_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_slice_base_spec.erb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_slice_name %>::Views::Part do
-<%- if ruby_implicity_keyword_argument? -%>
+<%- if ruby_omit_hash_values? -%>
   subject { described_class.new(value:) }
 <%- else -%>
   subject { described_class.new(value: value) }

--- a/lib/hanami/rspec/generators/part/part_slice_base_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_slice_base_spec.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe <%= camelized_slice_name %>::Views::Part do
+  it "works" do
+    expect(subject).to be_kind_of(described_class)
+  end
+end

--- a/lib/hanami/rspec/generators/part/part_slice_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_slice_spec.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe <%= camelized_slice_name %>::Views::Parts::<%= camelized_name %> do
+  it "works" do
+    expect(subject).to be_kind_of(described_class)
+  end
+end

--- a/lib/hanami/rspec/generators/part/part_slice_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_slice_spec.erb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_slice_name %>::Views::Parts::<%= camelized_name %> do
+<%- if ruby_implicity_keyword_argument? -%>
+  subject { described_class.new(value:) }
+<%- else -%>
+  subject { described_class.new(value: value) }
+<%- end -%>
+  let(:value) { double("<%= underscored_name %>") }
+
   it "works" do
     expect(subject).to be_kind_of(described_class)
   end

--- a/lib/hanami/rspec/generators/part/part_slice_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_slice_spec.erb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_slice_name %>::Views::Parts::<%= camelized_name %> do
-<%- if ruby_implicity_keyword_argument? -%>
+<%- if ruby_omit_hash_values? -%>
   subject { described_class.new(value:) }
 <%- else -%>
   subject { described_class.new(value: value) }

--- a/lib/hanami/rspec/generators/part/part_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_spec.erb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_app_name %>::Views::Parts::<%= camelized_name %> do
+<%- if ruby_implicity_keyword_argument? -%>
+  subject { described_class.new(value:) }
+<%- else -%>
+  subject { described_class.new(value: value) }
+<%- end -%>
+  let(:value) { double("<%= underscored_name %>") }
+
   it "works" do
     expect(subject).to be_kind_of(described_class)
   end

--- a/lib/hanami/rspec/generators/part/part_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_spec.erb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_app_name %>::Views::Parts::<%= camelized_name %> do
-<%- if ruby_implicity_keyword_argument? -%>
+<%- if ruby_omit_hash_values? -%>
   subject { described_class.new(value:) }
 <%- else -%>
   subject { described_class.new(value: value) }

--- a/lib/hanami/rspec/generators/part/part_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_spec.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe <%= camelized_app_name %>::Views::Parts::<%= camelized_name %> do
+  it "works" do
+    expect(subject).to be_kind_of(described_class)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "hanami/rspec"
+require "fileutils"
+
+TMP = File.join(Dir.pwd, "tmp")
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -9,6 +12,10 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
+  end
+
+  config.after do
+    FileUtils.rm_rf(TMP) if File.directory?(TMP)
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
@@ -28,5 +35,3 @@ RSpec.configure do |config|
 
   Kernel.srand config.seed
 end
-
-TMP = File.join(Dir.pwd, "tmp")

--- a/spec/unit/hanami/rspec/commands/generate/part_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/part_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
           within_application_directory do
             subject.call({name: part_name})
 
-            if ruby_implicity_keyword_argument?
+            if ruby_omit_hash_values?
               base_part_spec = <<~EXPECTED
                 # frozen_string_literal: true
 
@@ -50,7 +50,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
               expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
             end
 
-            unless ruby_implicity_keyword_argument?
+            unless ruby_omit_hash_values?
               base_part_spec = <<~EXPECTED
                 # frozen_string_literal: true
 
@@ -90,7 +90,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
             subject.call({name: part_name})
 
-            if ruby_implicity_keyword_argument?
+            if ruby_omit_hash_values?
               <<~EXPECTED
                 # frozen_string_literal: true
 
@@ -133,7 +133,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
           within_application_directory do
             subject.call({slice: slice, name: part_name})
 
-            if ruby_implicity_keyword_argument?
+            if ruby_omit_hash_values?
               base_part_spec = <<~EXPECTED
                 # frozen_string_literal: true
 
@@ -177,7 +177,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
               expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
             end
 
-            unless ruby_implicity_keyword_argument?
+            unless ruby_omit_hash_values?
               base_part_spec = <<~EXPECTED
                 # frozen_string_literal: true
 
@@ -232,7 +232,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
             subject.call({slice: slice, name: part_name})
 
-            if ruby_implicity_keyword_argument?
+            if ruby_omit_hash_values?
               part_spec = <<~EXPECTED
                 # frozen_string_literal: true
 
@@ -304,7 +304,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
     end
   end
 
-  def ruby_implicity_keyword_argument?
+  def ruby_omit_hash_values?
     RUBY_VERSION >= "3.1"
   end
 end

--- a/spec/unit/hanami/rspec/commands/generate/part_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/part_spec.rb
@@ -15,20 +15,63 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
     let(:part_name) { "client" }
 
     context "app" do
-      it "generates spec file" do
-        within_application_directory do
-          subject.call({name: part_name})
+      context "without base part" do
+        it "generates spec file" do
+          within_application_directory do
+            subject.call({name: part_name})
 
-          part_spec = <<~EXPECTED
-            # frozen_string_literal: true
+            base_part_spec = <<~EXPECTED
+              # frozen_string_literal: true
 
-            RSpec.describe #{app_name}::Views::Parts::Client do
-              it "works" do
-                expect(subject).to be_kind_of(described_class)
+              RSpec.describe #{app_name}::Views::Part do
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
+                end
               end
-            end
-          EXPECTED
-          expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
+            EXPECTED
+            expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
+
+            part_spec = <<~EXPECTED
+              # frozen_string_literal: true
+
+              RSpec.describe #{app_name}::Views::Parts::Client do
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
+                end
+              end
+            EXPECTED
+            expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
+          end
+        end
+      end
+
+      context "with base part" do
+        it "generates spec file" do
+          within_application_directory do
+            base_part_spec = <<~EXPECTED
+              # frozen_string_literal: true
+
+              RSpec.describe #{app_name}::Views::Part do
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
+                end
+              end
+            EXPECTED
+            fs.write("spec/views/part_spec.rb", base_part_spec)
+
+            subject.call({name: part_name})
+
+            part_spec = <<~EXPECTED
+              # frozen_string_literal: true
+
+              RSpec.describe #{app_name}::Views::Parts::Client do
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
+                end
+              end
+            EXPECTED
+            expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
+          end
         end
       end
     end
@@ -37,20 +80,85 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
       let(:slice) { "main" }
       let(:slice_name) { "Main" }
 
-      it "generates spec file" do
-        within_application_directory do
-          subject.call({slice: slice, name: part_name})
+      context "without base part" do
+        it "generates spec file" do
+          within_application_directory do
+            subject.call({slice: slice, name: part_name})
 
-          part_spec = <<~EXPECTED
-            # frozen_string_literal: true
+            base_part_spec = <<~EXPECTED
+              # frozen_string_literal: true
 
-            RSpec.describe #{slice_name}::Views::Parts::Client do
-              it "works" do
-                expect(subject).to be_kind_of(described_class)
+              RSpec.describe #{app_name}::Views::Part do
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
+                end
               end
-            end
-          EXPECTED
-          expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
+            EXPECTED
+            expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
+
+            base_slice_part_spec = <<~EXPECTED
+              # frozen_string_literal: true
+
+              RSpec.describe #{slice_name}::Views::Part do
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
+                end
+              end
+            EXPECTED
+            expect(fs.read("spec/slices/#{slice}/views/part_spec.rb")).to eq(base_slice_part_spec)
+
+            part_spec = <<~EXPECTED
+              # frozen_string_literal: true
+
+              RSpec.describe #{slice_name}::Views::Parts::Client do
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
+                end
+              end
+            EXPECTED
+            expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
+          end
+        end
+      end
+
+      context "with base part" do
+        it "generates spec file" do
+          within_application_directory do
+            base_part_spec = <<~EXPECTED
+              # frozen_string_literal: true
+
+              RSpec.describe #{app_name}::Views::Part do
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
+                end
+              end
+            EXPECTED
+            fs.write("spec/views/part_spec.rb", base_part_spec)
+
+            base_slice_part_spec = <<~EXPECTED
+              # frozen_string_literal: true
+
+              RSpec.describe #{slice_name}::Views::Part do
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
+                end
+              end
+            EXPECTED
+            fs.write("spec/slices/#{slice}/views/part_spec.rb", base_slice_part_spec)
+
+            subject.call({slice: slice, name: part_name})
+
+            part_spec = <<~EXPECTED
+              # frozen_string_literal: true
+
+              RSpec.describe #{slice_name}::Views::Parts::Client do
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
+                end
+              end
+            EXPECTED
+            expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
+          end
         end
       end
     end

--- a/spec/unit/hanami/rspec/commands/generate/part_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/part_spec.rb
@@ -20,27 +20,65 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
           within_application_directory do
             subject.call({name: part_name})
 
-            base_part_spec = <<~EXPECTED
-              # frozen_string_literal: true
+            if ruby_implicity_keyword_argument?
+              base_part_spec = <<~EXPECTED
+                # frozen_string_literal: true
 
-              RSpec.describe #{app_name}::Views::Part do
-                it "works" do
-                  expect(subject).to be_kind_of(described_class)
+                RSpec.describe #{app_name}::Views::Part do
+                  subject { described_class.new(value:) }
+                  let(:value) { double("value") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
                 end
-              end
-            EXPECTED
-            expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
+              EXPECTED
+              expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
 
-            part_spec = <<~EXPECTED
-              # frozen_string_literal: true
+              part_spec = <<~EXPECTED
+                # frozen_string_literal: true
 
-              RSpec.describe #{app_name}::Views::Parts::Client do
-                it "works" do
-                  expect(subject).to be_kind_of(described_class)
+                RSpec.describe #{app_name}::Views::Parts::Client do
+                  subject { described_class.new(value:) }
+                  let(:value) { double("client") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
                 end
-              end
-            EXPECTED
-            expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
+              EXPECTED
+              expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
+            end
+
+            unless ruby_implicity_keyword_argument?
+              base_part_spec = <<~EXPECTED
+                # frozen_string_literal: true
+
+                RSpec.describe #{app_name}::Views::Part do
+                  subject { described_class.new(value: value) }
+                  let(:value) { double("value") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
+                end
+              EXPECTED
+              expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
+
+              part_spec = <<~EXPECTED
+                # frozen_string_literal: true
+
+                RSpec.describe #{app_name}::Views::Parts::Client do
+                  subject { described_class.new(value: value) }
+                  let(:value) { double("client") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
+                end
+              EXPECTED
+              expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
+            end
           end
         end
       end
@@ -48,29 +86,39 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
       context "with base part" do
         it "generates spec file" do
           within_application_directory do
-            base_part_spec = <<~EXPECTED
-              # frozen_string_literal: true
-
-              RSpec.describe #{app_name}::Views::Part do
-                it "works" do
-                  expect(subject).to be_kind_of(described_class)
-                end
-              end
-            EXPECTED
-            fs.write("spec/views/part_spec.rb", base_part_spec)
+            fs.touch("spec/views/part_spec.rb")
 
             subject.call({name: part_name})
 
-            part_spec = <<~EXPECTED
-              # frozen_string_literal: true
+            if ruby_implicity_keyword_argument?
+              <<~EXPECTED
+                # frozen_string_literal: true
 
-              RSpec.describe #{app_name}::Views::Parts::Client do
-                it "works" do
-                  expect(subject).to be_kind_of(described_class)
+                RSpec.describe #{app_name}::Views::Parts::Client do
+                  subject { described_class.new(value:) }
+                  let(:value) { double("client") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
                 end
-              end
-            EXPECTED
-            expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
+              EXPECTED
+            else
+              part_spec = <<~EXPECTED
+                # frozen_string_literal: true
+
+                RSpec.describe #{app_name}::Views::Parts::Client do
+                  subject { described_class.new(value: value) }
+                  let(:value) { double("client") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
+                end
+              EXPECTED
+
+              expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
+            end
           end
         end
       end
@@ -85,38 +133,93 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
           within_application_directory do
             subject.call({slice: slice, name: part_name})
 
-            base_part_spec = <<~EXPECTED
-              # frozen_string_literal: true
+            if ruby_implicity_keyword_argument?
+              base_part_spec = <<~EXPECTED
+                # frozen_string_literal: true
 
-              RSpec.describe #{app_name}::Views::Part do
-                it "works" do
-                  expect(subject).to be_kind_of(described_class)
+                RSpec.describe #{app_name}::Views::Part do
+                  subject { described_class.new(value:) }
+                  let(:value) { double("value") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
                 end
-              end
-            EXPECTED
-            expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
+              EXPECTED
+              expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
 
-            base_slice_part_spec = <<~EXPECTED
-              # frozen_string_literal: true
+              base_slice_part_spec = <<~EXPECTED
+                # frozen_string_literal: true
 
-              RSpec.describe #{slice_name}::Views::Part do
-                it "works" do
-                  expect(subject).to be_kind_of(described_class)
+                RSpec.describe #{slice_name}::Views::Part do
+                  subject { described_class.new(value:) }
+                  let(:value) { double("value") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
                 end
-              end
-            EXPECTED
-            expect(fs.read("spec/slices/#{slice}/views/part_spec.rb")).to eq(base_slice_part_spec)
+              EXPECTED
+              expect(fs.read("spec/slices/#{slice}/views/part_spec.rb")).to eq(base_slice_part_spec)
 
-            part_spec = <<~EXPECTED
-              # frozen_string_literal: true
+              part_spec = <<~EXPECTED
+                # frozen_string_literal: true
 
-              RSpec.describe #{slice_name}::Views::Parts::Client do
-                it "works" do
-                  expect(subject).to be_kind_of(described_class)
+                RSpec.describe #{slice_name}::Views::Parts::Client do
+                  subject { described_class.new(value:) }
+                  let(:value) { double("client") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
                 end
-              end
-            EXPECTED
-            expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
+              EXPECTED
+              expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
+            end
+
+            unless ruby_implicity_keyword_argument?
+              base_part_spec = <<~EXPECTED
+                # frozen_string_literal: true
+
+                RSpec.describe #{app_name}::Views::Part do
+                  subject { described_class.new(value: value) }
+                  let(:value) { double("value") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
+                end
+              EXPECTED
+              expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
+
+              base_slice_part_spec = <<~EXPECTED
+                # frozen_string_literal: true
+
+                RSpec.describe #{slice_name}::Views::Part do
+                  subject { described_class.new(value: value) }
+                  let(:value) { double("value") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
+                end
+              EXPECTED
+              expect(fs.read("spec/slices/#{slice}/views/part_spec.rb")).to eq(base_slice_part_spec)
+
+              part_spec = <<~EXPECTED
+                # frozen_string_literal: true
+
+                RSpec.describe #{slice_name}::Views::Parts::Client do
+                  subject { described_class.new(value: value) }
+                  let(:value) { double("client") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
+                end
+              EXPECTED
+              expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
+            end
           end
         end
       end
@@ -124,39 +227,38 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
       context "with base part" do
         it "generates spec file" do
           within_application_directory do
-            base_part_spec = <<~EXPECTED
-              # frozen_string_literal: true
-
-              RSpec.describe #{app_name}::Views::Part do
-                it "works" do
-                  expect(subject).to be_kind_of(described_class)
-                end
-              end
-            EXPECTED
-            fs.write("spec/views/part_spec.rb", base_part_spec)
-
-            base_slice_part_spec = <<~EXPECTED
-              # frozen_string_literal: true
-
-              RSpec.describe #{slice_name}::Views::Part do
-                it "works" do
-                  expect(subject).to be_kind_of(described_class)
-                end
-              end
-            EXPECTED
-            fs.write("spec/slices/#{slice}/views/part_spec.rb", base_slice_part_spec)
+            fs.touch("spec/views/part_spec.rb")
+            fs.touch("spec/slices/#{slice}/views/part_spec.rb")
 
             subject.call({slice: slice, name: part_name})
 
-            part_spec = <<~EXPECTED
-              # frozen_string_literal: true
+            if ruby_implicity_keyword_argument?
+              part_spec = <<~EXPECTED
+                # frozen_string_literal: true
 
-              RSpec.describe #{slice_name}::Views::Parts::Client do
-                it "works" do
-                  expect(subject).to be_kind_of(described_class)
+                RSpec.describe #{slice_name}::Views::Parts::Client do
+                  subject { described_class.new(value:) }
+                  let(:value) { double("client") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
                 end
-              end
-            EXPECTED
+              EXPECTED
+            else
+              part_spec = <<~EXPECTED
+                # frozen_string_literal: true
+
+                RSpec.describe #{slice_name}::Views::Parts::Client do
+                  subject { described_class.new(value: value) }
+                  let(:value) { double("client") }
+
+                  it "works" do
+                    expect(subject).to be_kind_of(described_class)
+                  end
+                end
+              EXPECTED
+            end
             expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
           end
         end
@@ -200,5 +302,9 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
       yield
     end
+  end
+
+  def ruby_implicity_keyword_argument?
+    RUBY_VERSION >= "3.1"
   end
 end

--- a/spec/unit/hanami/rspec/commands/generate/part_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/part_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "securerandom"
+
+RSpec.describe Hanami::RSpec::Commands::Generate::Part do
+  describe "#call" do
+    subject { described_class.new(fs: fs, inflector: inflector) }
+
+    let(:fs) { Dry::Files.new }
+    let(:inflector) { Dry::Inflector.new }
+
+    let(:app_name) { "Bookshelf" }
+
+    let(:part_name) { "client" }
+
+    context "app" do
+      it "generates spec file" do
+        within_application_directory do
+          subject.call({name: part_name})
+
+          part_spec = <<~EXPECTED
+            # frozen_string_literal: true
+
+            RSpec.describe #{app_name}::Views::Parts::Client do
+              it "works" do
+                expect(subject).to be_kind_of(described_class)
+              end
+            end
+          EXPECTED
+          expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
+        end
+      end
+    end
+
+    context "slice" do
+      let(:slice) { "main" }
+      let(:slice_name) { "Main" }
+
+      it "generates spec file" do
+        within_application_directory do
+          subject.call({slice: slice, name: part_name})
+
+          part_spec = <<~EXPECTED
+            # frozen_string_literal: true
+
+            RSpec.describe #{slice_name}::Views::Parts::Client do
+              it "works" do
+                expect(subject).to be_kind_of(described_class)
+              end
+            end
+          EXPECTED
+          expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
+        end
+      end
+    end
+  end
+
+  private
+
+  def within_application_directory(app: app_name)
+    dir = fs.join(TMP, SecureRandom.uuid, app)
+
+    fs.mkdir(dir)
+    fs.chdir(dir) do
+      app_code = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami"
+
+        module #{app}
+          class App < Hanami::App
+          end
+        end
+      CODE
+      fs.write("config/app.rb", app_code)
+
+      routes = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami/routes"
+
+        module #{app}
+          class Routes < Hanami::Routes
+            define do
+              root { "Hello from Hanami" }
+            end
+          end
+        end
+      CODE
+      fs.write("config/routes.rb", routes)
+
+      yield
+    end
+  end
+end


### PR DESCRIPTION
## Feature

Support RSpec generation for `hanami generate part` (see https://github.com/hanami/cli/pull/117)

## App

```shell
$ bundle exec hanami generate part user
# ...
Created spec/views/parts/user_spec.rb
```

```ruby
# frozen_string_literal: true

RSpec.describe Bookshelf::Views::Parts::User do
  it "works" do
    expect(subject).to be_kind_of(described_class)
  end
end
```

## Slice

```shell
$ bundle exec hanami generate part user --slice=admin
# ...
Created spec/slices/admin/views/parts/user_spec.rb
```

```ruby
# frozen_string_literal: true

RSpec.describe Admin::Views::Parts::User do
  it "works" do
    expect(subject).to be_kind_of(described_class)
  end
end
```

---

Ref https://github.com/hanami/cli/pull/117
Ref https://github.com/hanami/cli/issues/113