### PR TITLE
Change the default generated request spec for `hanami new`

### DIFF
--- a/lib/hanami/rspec/generators/request.rb
+++ b/lib/hanami/rspec/generators/request.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe "Root", type: :request do
-  it "is successful" do
+  it "is not found" do
     get "/"
 
-    # Find me in `config/routes.rb`
-    expect(last_response).to be_successful
-    expect(last_response.body).to eq("Hello from Hanami")
+    # Generate new action via:
+    #   `bundle exec hanami generate action home.index --url=/`
+    expect(last_response.status).to be(404)
   end
 end

--- a/spec/unit/hanami/rspec/commands/install_spec.rb
+++ b/spec/unit/hanami/rspec/commands/install_spec.rb
@@ -105,12 +105,12 @@ RSpec.describe Hanami::RSpec::Commands::Install do
         # frozen_string_literal: true
 
         RSpec.describe "Root", type: :request do
-          it "is successful" do
+          it "is not found" do
             get "/"
 
-            # Find me in `config/routes.rb`
-            expect(last_response).to be_successful
-            expect(last_response.body).to eq("Hello from Hanami")
+            # Generate new action via:
+            #   `bundle exec hanami generate action home.index --url=/`
+            expect(last_response.status).to be(404)
           end
         end
       EOF


### PR DESCRIPTION
## Fix

As of 2.1.0, we don't generate a default route anymore.
As a result, in the `test` environment, a GET request to `/` is a 404 (Not Found).

The default request spec is used to assert that the root path was successfully found (200).
Running for the first time the specs, after generating the app results in a failing test.

👉 While having a failing test is in line with TDD/BDD philosophy as a clear indicator to implement a missing feature, the experience can be unpleasant for newcomers.
The uncertainty of trying a new framework can be a source of anxiety, and seeing a failing test can have negative emotional imprinting.

👉 My take is to generate a test that expects a 404.
It communicates to the user that we decided to generate an app with a missing root route.
Reassuring twice for the user: it's not them, Hanami team knows what they're doing.

---

### Before

Negative imprinting: failing spec.

```shell
⚡ bundle exec rake
/Users/jodosha/.rubies/ruby-3.2.2/bin/ruby -I/Users/jodosha/.gem/ruby/3.2.2/gems/rspec-core-3.12.2/lib:/Users/jodosha/.gem/ruby/3.2.2/gems/rspec-support-3.12.1/lib /Users/jodosha/.gem/ruby/3.2.2/gems/rspec-core-3.12.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Randomized with seed 42204

Root
  is successful (FAILED - 1)

Failures:

  1) Root is successful
     Failure/Error: expect(last_response).to be_successful
       expected `#<Rack::MockResponse:0x000000010c312b28 @original_headers={"Content-Type"=>"text/plain; charset=utf-8...:45:in `invoke'\n - rspec-core (3.12.2) exe/rspec:4:in `<main>'\n\n"], @buffered=true, @length=4094>.successful?` to be truthy, got false
     # ./spec/requests/root_spec.rb:8:in `block (2 levels) in <top (required)>'

Top 1 slowest examples (0.07353 seconds, 95.7% of total time):
  Root is successful
    0.07353 seconds ./spec/requests/root_spec.rb:4

Finished in 0.07687 seconds (files took 0.4163 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/requests/root_spec.rb:4 # Root is successful

Randomized with seed 42204

/Users/jodosha/.rubies/ruby-3.2.2/bin/ruby -I/Users/jodosha/.gem/ruby/3.2.2/gems/rspec-core-3.12.2/lib:/Users/jodosha/.gem/ruby/3.2.2/gems/rspec-support-3.12.1/lib /Users/jodosha/.gem/ruby/3.2.2/gems/rspec-core-3.12.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```

---

### After

Positive imprinting: passing spec.

```shell
⚡ bundle exec rake
/Users/jodosha/.rubies/ruby-3.2.2/bin/ruby -I/Users/jodosha/.gem/ruby/3.2.2/gems/rspec-core-3.12.2/lib:/Users/jodosha/.gem/ruby/3.2.2/gems/rspec-support-3.12.1/lib /Users/jodosha/.gem/ruby/3.2.2/gems/rspec-core-3.12.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Randomized with seed 59621

Root
  is not found

Top 1 slowest examples (0.06069 seconds, 95.3% of total time):
  Root is not found
    0.06069 seconds ./spec/requests/root_spec.rb:4

Finished in 0.0637 seconds (files took 0.3812 seconds to load)
1 example, 0 failures

Randomized with seed 59621
```

---

Closes #17 