### PR TITLE
Install capybara

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 RSpec support for Hanami
 
+### Added
+
+- [Tim Riley] Install Capybara and generate `spec/support/capybara.rb` in `hanami install` hook.
+
 ## v2.1.0.rc1 - 2023-11-01
 
 ### Added

--- a/lib/hanami/rspec/commands.rb
+++ b/lib/hanami/rspec/commands.rb
@@ -17,6 +17,7 @@ module Hanami
           copy_dotrspec
           copy_spec_helper
           copy_support_rspec
+          copy_support_features
           copy_support_requests
 
           generate_request_spec
@@ -51,6 +52,13 @@ module Hanami
           fs.cp(
             fs.expand_path(fs.join("generators", "support_rspec.rb"), __dir__),
             fs.expand_path(fs.join("spec", "support", "rspec.rb"))
+          )
+        end
+
+        def copy_support_features
+          fs.cp(
+            fs.expand_path(fs.join("generators", "support_features.rb"), __dir__),
+            fs.expand_path(fs.join("spec", "support", "features.rb"))
           )
         end
 

--- a/lib/hanami/rspec/generators/gemfile
+++ b/lib/hanami/rspec/generators/gemfile
@@ -1,4 +1,5 @@
 
 group :test do
+  gem "capybara"
   gem "rack-test"
 end

--- a/lib/hanami/rspec/generators/helper.rb
+++ b/lib/hanami/rspec/generators/helper.rb
@@ -7,4 +7,5 @@ ENV["HANAMI_ENV"] ||= "test"
 require "hanami/prepare"
 
 require_relative "support/rspec"
+require_relative "support/features"
 require_relative "support/requests"

--- a/lib/hanami/rspec/generators/support_features.rb
+++ b/lib/hanami/rspec/generators/support_features.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "capybara/rspec"
+
+Capybara.app = Hanami.app

--- a/spec/unit/hanami/rspec/commands/install_spec.rb
+++ b/spec/unit/hanami/rspec/commands/install_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Hanami::RSpec::Commands::Install do
       # Gemfile
       gemfile = <<~EOF
         group :test do
+          gem "capybara"
           gem "rack-test"
         end
       EOF
@@ -47,6 +48,7 @@ RSpec.describe Hanami::RSpec::Commands::Install do
         require "hanami/prepare"
 
         require_relative "support/rspec"
+        require_relative "support/features"
         require_relative "support/requests"
       EOF
       expect(fs.read("spec/spec_helper.rb")).to eq(spec_helper)
@@ -82,6 +84,16 @@ RSpec.describe Hanami::RSpec::Commands::Install do
         end
       EOF
       expect(fs.read("spec/support/rspec.rb")).to eq(support_rspec)
+
+      # spec/support/features.rb
+      support_features = <<~EOF
+        # frozen_string_literal: true
+
+        require "capybara/rspec"
+
+        Capybara.app = Hanami.app
+      EOF
+      expect(fs.read("spec/support/features.rb")).to eq(support_features)
 
       # spec/support/requests.rb
       support_requests = <<~EOF


### PR DESCRIPTION
This helps make feature specs usable right from the very beginning, and will allow us to remove a bunch of manual setup instructions from our getting started guide for 2.1.