### PR TITLE
Skip generating tests with --skip-tests flag given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 RSpec support for Hanami
 
+### Added
+
+- [Tim Riley] Skip generating tests for actions and parts when `--skip-tests` CLI flag is given
+
 ## v2.1.0.rc1 - 2023-11-01
 
 ### Added

--- a/lib/hanami/rspec/commands.rb
+++ b/lib/hanami/rspec/commands.rb
@@ -91,6 +91,9 @@ module Hanami
           # @api private
           def call(options, **)
             # FIXME: dry-cli kwargs aren't correctly forwarded in Ruby 3
+
+            return if options[:skip_tests]
+
             slice = inflector.underscore(Shellwords.shellescape(options[:slice])) if options[:slice]
             name = inflector.underscore(Shellwords.shellescape(options[:name]))
             *controller, action = name.split(ACTION_SEPARATOR)
@@ -107,6 +110,9 @@ module Hanami
           # @api private
           def call(options, **)
             # FIXME: dry-cli kwargs aren't correctly forwarded in Ruby 3
+
+            return if options[:skip_tests]
+
             slice = inflector.underscore(Shellwords.shellescape(options[:slice])) if options[:slice]
             name = inflector.underscore(Shellwords.shellescape(options[:name]))
 

--- a/spec/unit/hanami/rspec/commands/generate/action_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/action_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
           end
         end
       end
+
+      context "skip_tests given" do
+        it "does not generate a spec file" do
+          within_application_directory do
+            subject.call({name: action_name, skip_tests: true})
+
+            expect(fs.exist?("spec/actions/client/create_spec.rb")).to be false
+          end
+        end
+      end
     end
 
     context "slice" do
@@ -82,6 +92,16 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
             end
           EXPECTED
           expect(fs.read("spec/slices/#{slice}/actions/client/create_spec.rb")).to eq(action_spec)
+        end
+      end
+
+      context "skip_tests given" do
+        it "does not generate a spec file" do
+          within_application_directory do
+            subject.call({slice: slice, name: action_name, skip_tests: true})
+
+            expect(fs.exist?("spec/slices/#{slice}/actions/client/create_spec.rb")).to be false
+          end
         end
       end
     end

--- a/spec/unit/hanami/rspec/commands/generate/part_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/part_spec.rb
@@ -122,6 +122,16 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
           end
         end
       end
+
+      context "skip_tests given" do
+        it "does not generate spec file" do
+          within_application_directory do
+            subject.call({name: part_name, skip_tests: true})
+
+            expect(fs.exist?("spec/views/parts/client_spec.rb")).to be false
+          end
+        end
+      end
     end
 
     context "slice" do
@@ -260,6 +270,16 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
               EXPECTED
             end
             expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
+          end
+        end
+      end
+
+      context "skip_tests given" do
+        it "does not generate spec file" do
+          within_application_directory do
+            subject.call({slice: slice, name: part_name, skip_tests: true})
+
+            expect(fs.exist?("spec/slices/#{slice}/views/parts/client_spec.rb")).to be false
           end
         end
       end


### PR DESCRIPTION
Having the ability to skip tests when generating an action or part is useful if you know you're going to test it in _some other way_ than what we generate by default.

For example, when working on a web app, and when using Capybara-driven feature specs, we generally don't want request specs generated for each action class.

Making this change allows us to have the user run through our "building a web app" getting started guide without generating a bunch of request specs that will clutter up their new app and start failing as they change the app according to the guide.

See https://github.com/hanami/cli/pull/126 for where we add the `--skip-tests` flag to the CLI commands in the first place.