### PR TITLE
Add include Dry::Monads[:result] to Rspec blocks

### DIFF
--- a/lib/hanami/rspec/commands.rb
+++ b/lib/hanami/rspec/commands.rb
@@ -19,6 +19,7 @@ module Hanami
           copy_spec_helper
           copy_support_rspec
           copy_support_features
+          copy_support_operations
           copy_support_requests
 
           generate_request_spec
@@ -65,6 +66,13 @@ module Hanami
           fs.cp(
             fs.expand_path(fs.join("generators", "support_features.rb"), __dir__),
             fs.expand_path(fs.join("spec", "support", "features.rb"))
+          )
+        end
+
+        def copy_support_operations
+          fs.cp(
+            fs.expand_path(fs.join("generators", "support_operations.rb"), __dir__),
+            fs.expand_path(fs.join("spec", "support", "operations.rb"))
           )
         end
 

--- a/lib/hanami/rspec/generators/helper.rb
+++ b/lib/hanami/rspec/generators/helper.rb
@@ -8,4 +8,5 @@ require "hanami/prepare"
 
 require_relative "support/rspec"
 require_relative "support/features"
+require_relative "support/operations"
 require_relative "support/requests"

--- a/lib/hanami/rspec/generators/support_operations.rb
+++ b/lib/hanami/rspec/generators/support_operations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+
+RSpec.configure do |config|
+  # Provide `Success` and `Failure` for testing operation results
+  config.include Dry::Monads[:result]
+end

--- a/lib/hanami/rspec/generators/support_rspec.rb
+++ b/lib/hanami/rspec/generators/support_rspec.rb
@@ -58,4 +58,7 @@ RSpec.configure do |config|
   # related to randomization by passing the same `--seed` value as the one that
   # triggered the failure.
   Kernel.srand config.seed
+
+  # This allows you to use Success(..) and Failure(..) for dry-operation results
+  config.include Dry::Monads[:result]
 end

--- a/lib/hanami/rspec/generators/support_rspec.rb
+++ b/lib/hanami/rspec/generators/support_rspec.rb
@@ -58,7 +58,4 @@ RSpec.configure do |config|
   # related to randomization by passing the same `--seed` value as the one that
   # triggered the failure.
   Kernel.srand config.seed
-
-  # This allows you to use Success(..) and Failure(..) for dry-operation results
-  config.include Dry::Monads[:result]
 end

--- a/spec/unit/hanami/rspec/commands/install_spec.rb
+++ b/spec/unit/hanami/rspec/commands/install_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Hanami::RSpec::Commands::Install do
 
         require_relative "support/rspec"
         require_relative "support/features"
+        require_relative "support/operations"
         require_relative "support/requests"
       EOF
       expect(fs.read("spec/spec_helper.rb")).to eq(spec_helper)
@@ -121,9 +122,6 @@ RSpec.describe Hanami::RSpec::Commands::Install do
           # related to randomization by passing the same `--seed` value as the one that
           # triggered the failure.
           Kernel.srand config.seed
-
-          # This allows you to use Success(..) and Failure(..) for dry-operation results
-          config.include Dry::Monads[:result]
         end
       EOF
       expect(fs.read("spec/support/rspec.rb")).to eq(support_rspec)
@@ -137,6 +135,18 @@ RSpec.describe Hanami::RSpec::Commands::Install do
         Capybara.app = Hanami.app
       EOF
       expect(fs.read("spec/support/features.rb")).to eq(support_features)
+
+      support_operations = <<~EOF
+        # frozen_string_literal: true
+
+        require "dry/monads"
+
+        RSpec.configure do |config|
+          # Provide `Success` and `Failure` for testing operation results
+          config.include Dry::Monads[:result]
+        end
+      EOF
+      expect(fs.read("spec/support/operations.rb")).to eq(support_operations)
 
       # spec/support/requests.rb
       support_requests = <<~EOF

--- a/spec/unit/hanami/rspec/commands/install_spec.rb
+++ b/spec/unit/hanami/rspec/commands/install_spec.rb
@@ -121,6 +121,9 @@ RSpec.describe Hanami::RSpec::Commands::Install do
           # related to randomization by passing the same `--seed` value as the one that
           # triggered the failure.
           Kernel.srand config.seed
+
+          # This allows you to use Success(..) and Failure(..) for dry-operation results
+          config.include Dry::Monads[:result]
         end
       EOF
       expect(fs.read("spec/support/rspec.rb")).to eq(support_rspec)


### PR DESCRIPTION
We currently don't allow people to opt-out of dry-operation on `hanami new` so it's safe to assume they'll have dry-monads as a transitive dependency. If they choose to remove it, it'll be clear that they can delete this line without any issues