### PR TITLE
Require all files in spec/support/ by default

### DIFF
--- a/lib/hanami/rspec/generators/helper.rb
+++ b/lib/hanami/rspec/generators/helper.rb
@@ -6,4 +6,4 @@ SPEC_ROOT = Pathname(__dir__).realpath.freeze
 ENV["HANAMI_ENV"] ||= "test"
 require "hanami/prepare"
 
-Dir["./spec/support/**/*.rb"].each { |f| require f }
+SPEC_ROOT.glob("support/**/*.rb").each { |f| require f }

--- a/lib/hanami/rspec/generators/helper.rb
+++ b/lib/hanami/rspec/generators/helper.rb
@@ -6,7 +6,4 @@ SPEC_ROOT = Pathname(__dir__).realpath.freeze
 ENV["HANAMI_ENV"] ||= "test"
 require "hanami/prepare"
 
-require_relative "support/rspec"
-require_relative "support/features"
-require_relative "support/operations"
-require_relative "support/requests"
+Dir["./spec/support/**/*.rb"].each { |f| require f }

--- a/spec/unit/hanami/rspec/commands/install_spec.rb
+++ b/spec/unit/hanami/rspec/commands/install_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Hanami::RSpec::Commands::Install do
         ENV["HANAMI_ENV"] ||= "test"
         require "hanami/prepare"
 
-        Dir["./spec/support/**/*.rb"].each { |f| require f }
+        SPEC_ROOT.glob("support/**/*.rb").each { |f| require f }
       EOF
       expect(fs.read("spec/spec_helper.rb")).to eq(spec_helper)
 

--- a/spec/unit/hanami/rspec/commands/install_spec.rb
+++ b/spec/unit/hanami/rspec/commands/install_spec.rb
@@ -53,10 +53,7 @@ RSpec.describe Hanami::RSpec::Commands::Install do
         ENV["HANAMI_ENV"] ||= "test"
         require "hanami/prepare"
 
-        require_relative "support/rspec"
-        require_relative "support/features"
-        require_relative "support/operations"
-        require_relative "support/requests"
+        Dir["./spec/support/**/*.rb"].each { |f| require f }
       EOF
       expect(fs.read("spec/spec_helper.rb")).to eq(spec_helper)
 


### PR DESCRIPTION
I'm making an assumption here that when people put something into `spec/support/` they want it required for every spec, without having to remember to manually add it to the list of `require_relative`s in `spec/spec_helper.rb`.

I feel like this is a pretty common pattern too, and people can always switch back to require_relatives if they'd like.