### PR TITLE
Conditionally install hooks, based on what's bundled

### DIFF
--- a/lib/hanami/rspec.rb
+++ b/lib/hanami/rspec.rb
@@ -34,8 +34,14 @@ module Hanami
     if Hanami::CLI.within_hanami_app?
       Hanami::CLI.after "install", Commands::Install
       Hanami::CLI.after "generate slice", Commands::Generate::Slice
-      Hanami::CLI.after "generate action", Commands::Generate::Action
-      Hanami::CLI.after "generate part", Commands::Generate::Part
+      
+      if Hanami.bundled?("hanami-controller")
+        Hanami::CLI.after "generate action", Commands::Generate::Action
+      end
+
+      if Hanami.bundled?("hanami-view")
+        Hanami::CLI.after "generate part", Commands::Generate::Part
+      end
     end
   end
 end

--- a/lib/hanami/rspec.rb
+++ b/lib/hanami/rspec.rb
@@ -34,7 +34,7 @@ module Hanami
     if Hanami::CLI.within_hanami_app?
       Hanami::CLI.after "install", Commands::Install
       Hanami::CLI.after "generate slice", Commands::Generate::Slice
-      
+
       if Hanami.bundled?("hanami-controller")
         Hanami::CLI.after "generate action", Commands::Generate::Action
       end


### PR DESCRIPTION
I know my setup is annoying, but I don't have `hanami-view` in https://github.com/katafrakt/palaver. After an attempt to update to 2.2.rc1 I was faced with an error when starting the server:

```
bundler: failed to load command: hanami (/home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bin/hanami)
/home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/dry-cli-1.1.0/lib/dry/cli/registry.rb:281:in `block in command': unknown command: `generate part' (Dry::CLI::UnknownCommandError)
	from <internal:kernel>:90:in `tap'
	from /home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/dry-cli-1.1.0/lib/dry/cli/registry.rb:280:in `command'
	from /home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/dry-cli-1.1.0/lib/dry/cli/registry.rb:263:in `block in after'
	from /home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/dry-cli-1.1.0/lib/dry/cli/registry.rb:262:in `synchronize'
	from /home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/dry-cli-1.1.0/lib/dry/cli/registry.rb:262:in `after'
	from /home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/hanami-rspec-2.2.0.rc1/lib/hanami/rspec.rb:38:in `<module:RSpec>'
	from /home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/hanami-rspec-2.2.0.rc1/lib/hanami/rspec.rb:13:in `<module:Hanami>'
	from /home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/hanami-rspec-2.2.0.rc1/lib/hanami/rspec.rb:8:in `<top (required)>'
	from /home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/hanami-rspec-2.2.0.rc1/lib/hanami-rspec.rb:3:in `require_relative'
	from /home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/hanami-rspec-2.2.0.rc1/lib/hanami-rspec.rb:3:in `<top (required)>'
	from /home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
	from /home/katafrakt/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
```

I figured this was because of https://github.com/hanami/cli/commit/c3b575487c9d836a904bb0d20bf09e664ed736f7 - now the `generate part` command is only defined if `hanami-view` is present, but `hanami-rspec` tries to enhance it anyway.

So this PR adds relevant conditional logic here, to be on par with `hanami-cli`.