### PR TITLE
Switch to `before "install"` hook

### DIFF
--- a/lib/hanami/rspec.rb
+++ b/lib/hanami/rspec.rb
@@ -32,7 +32,7 @@ module Hanami
     require_relative "rspec/rake_tasks"
 
     if Hanami::CLI.within_hanami_app?
-      Hanami::CLI.after "install", Commands::Install
+      Hanami::CLI.before "install", Commands::Install
       Hanami::CLI.after "generate slice", Commands::Generate::Slice
 
       if Hanami.bundled?("hanami-controller")


### PR DESCRIPTION
Combined with `hanami install` now running a `bundle install`, this will ensure the testing-related gems added to the `Gemfile` will be installed as part of running `hanami new`.

See https://github.com/hanami/cli/pull/269