### PR TITLE
Add Ruby 3.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.4"
           - "3.3"
           - "3.2"
           - "3.1"

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,6 @@ end
 
 gem "dry-files", github: "dry-rb/dry-files", branch: "main"
 gem "dry-logger", github: "dry-rb/dry-logger", branch: "main"
-gem "dry-system", github: "dry-rb/dry-system", branch: "main"
-gem "dry-auto_inject", github: "dry-rb/dry-auto_inject", branch: "main"
 
 gem "hanami-utils", github: "hanami/utils", branch: "main"
 gem "hanami-cli", github: "hanami/cli", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ end
 gem "dry-files", github: "dry-rb/dry-files", branch: "main"
 gem "dry-logger", github: "dry-rb/dry-logger", branch: "main"
 gem "dry-system", github: "dry-rb/dry-system", branch: "main"
+gem "dry-auto_inject", github: "dry-rb/dry-auto_inject", branch: "main"
 
 gem "hanami-utils", github: "hanami/utils", branch: "main"
 gem "hanami-cli", github: "hanami/cli", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,6 @@ unless ENV["CI"]
   gem "yard"
 end
 
-gem "dry-files", github: "dry-rb/dry-files", branch: "main"
-gem "dry-logger", github: "dry-rb/dry-logger", branch: "main"
-
 gem "hanami-utils", github: "hanami/utils", branch: "main"
 gem "hanami-cli", github: "hanami/cli", branch: "main"
 gem "hanami", github: "hanami/hanami", branch: "main"


### PR DESCRIPTION
I noticed CI was breaking due to dry-system (from github) requiring a version of dry-auto_inject that's not released on RubyGems yet. So I added that... then realized I could actually remove both from the Gemfile, since dry-system's github source was added to get access to v1.1 before it was released on RubyGems. We don't need that anymore afaict.

I also went further and removed the github source for dry-files and dry-logger, since I don't think they're needed anymore. CI passes without them, and I think it's simpler to only depend on released gems (and the github source can always be re-added as necessary).

And thinking at a higher level / planning for the future, while we'll sometimes need to add github source to dry-rb gems in hanami repos, but I think we should remove those once they're not needed. (Compared to hanami gems, which can always reference main, so we stay up to date). WDYT @timriley @flash-gordon?