### PR TITLE
Fix CI for hanami-cli changes

### DIFF
--- a/lib/hanami/rspec/generators/action.rb
+++ b/lib/hanami/rspec/generators/action.rb
@@ -17,7 +17,19 @@ module Hanami
 
         # @since 2.0.0
         # @api private
-        def call(app, slice, controller, action, context: Hanami::CLI::Generators::App::ActionContext.new(inflector, app, slice, controller, action)) # rubocop:disable Layout/LineLength
+        def call(app, slice, controller, action)
+          context = Data.define(
+            :camelized_app_name,
+            :camelized_slice_name,
+            :camelized_controller_name,
+            :camelized_action_name
+          ).new(
+            camelized_app_name: inflector.camelize(app),
+            camelized_slice_name: slice ? inflector.camelize(slice) : nil,
+            camelized_controller_name: camelized_controller_name(controller),
+            camelized_action_name: inflector.camelize(action)
+          )
+
           if slice
             fs.write(
               "spec/slices/#{slice}/actions/#{controller_directory(controller)}/#{action}_spec.rb",
@@ -43,12 +55,18 @@ module Hanami
           fs.join(controller)
         end
 
+        # @api private
+        # @param controller [Array<String>]
+        def camelized_controller_name(controller)
+          controller.map { |part| inflector.camelize(part) }.join("::")
+        end
+
         def template(path, context)
           require "erb"
 
           ERB.new(
             File.read(__dir__ + "/action/#{path}")
-          ).result(context.ctx)
+          ).result(context.instance_eval { binding })
         end
 
         alias_method :t, :template

--- a/lib/hanami/rspec/generators/action.rb
+++ b/lib/hanami/rspec/generators/action.rb
@@ -18,16 +18,16 @@ module Hanami
         # @since 2.0.0
         # @api private
         def call(app, slice, controller, action)
-          context = Data.define(
+          context = Struct.new(
             :camelized_app_name,
             :camelized_slice_name,
             :camelized_controller_name,
             :camelized_action_name
           ).new(
-            camelized_app_name: inflector.camelize(app),
-            camelized_slice_name: slice ? inflector.camelize(slice) : nil,
-            camelized_controller_name: camelized_controller_name(controller),
-            camelized_action_name: inflector.camelize(action)
+            inflector.camelize(app),
+            slice ? inflector.camelize(slice) : nil,
+            camelized_controller_name(controller),
+            inflector.camelize(action)
           )
 
           if slice

--- a/lib/hanami/rspec/generators/part.rb
+++ b/lib/hanami/rspec/generators/part.rb
@@ -17,7 +17,21 @@ module Hanami
 
         # @since 2.1.0
         # @api private
-        def call(app, slice, name, context: Hanami::CLI::Generators::App::PartContext.new(inflector, app, slice, name))
+        def call(app, slice, name)
+          context = Data.define(
+            :camelized_app_name,
+            :camelized_slice_name,
+            :camelized_name,
+            :underscored_name,
+            :ruby_omit_hash_values?
+          ).new(
+            camelized_app_name: inflector.camelize(app),
+            camelized_slice_name: slice ? inflector.camelize(slice) : nil,
+            camelized_name: inflector.camelize(name),
+            underscored_name: inflector.underscore(name),
+            ruby_omit_hash_values?: RUBY_VERSION >= "3.1"
+          )
+
           if slice
             generate_for_slice(slice, context)
           else
@@ -90,7 +104,7 @@ module Hanami
           ERB.new(
             File.read(__dir__ + "/part/#{path}"),
             trim_mode: "-"
-          ).result(context.ctx)
+          ).result(context.instance_eval { binding })
         end
 
         # @since 2.1.0

--- a/lib/hanami/rspec/generators/part.rb
+++ b/lib/hanami/rspec/generators/part.rb
@@ -18,18 +18,18 @@ module Hanami
         # @since 2.1.0
         # @api private
         def call(app, slice, name)
-          context = Data.define(
+          context = Struct.new(
             :camelized_app_name,
             :camelized_slice_name,
             :camelized_name,
             :underscored_name,
             :ruby_omit_hash_values?
           ).new(
-            camelized_app_name: inflector.camelize(app),
-            camelized_slice_name: slice ? inflector.camelize(slice) : nil,
-            camelized_name: inflector.camelize(name),
-            underscored_name: inflector.underscore(name),
-            ruby_omit_hash_values?: RUBY_VERSION >= "3.1"
+            inflector.camelize(app),
+            slice ? inflector.camelize(slice) : nil,
+            inflector.camelize(name),
+            inflector.underscore(name),
+            RUBY_VERSION >= "3.1"
           )
 
           if slice

--- a/lib/hanami/rspec/generators/slice.rb
+++ b/lib/hanami/rspec/generators/slice.rb
@@ -18,9 +18,9 @@ module Hanami
         # @since 2.0.0
         # @api private
         def call(slice)
-          context = Data.define(:slice, :camelized_slice_name).new(
-            slice: slice,
-            camelized_slice_name: inflector.camelize(slice)
+          context = Struct.new(:slice, :camelized_slice_name).new(
+            slice,
+            inflector.camelize(slice)
           )
 
           fs.write("spec/slices/#{slice}/action_spec.rb", t("action_spec.erb", context))

--- a/lib/hanami/rspec/generators/slice.rb
+++ b/lib/hanami/rspec/generators/slice.rb
@@ -17,7 +17,12 @@ module Hanami
 
         # @since 2.0.0
         # @api private
-        def call(slice, context: Hanami::CLI::Generators::App::SliceContext.new(inflector, nil, slice, nil))
+        def call(slice)
+          context = Data.define(:slice, :camelized_slice_name).new(
+            slice: slice,
+            camelized_slice_name: inflector.camelize(slice)
+          )
+
           fs.write("spec/slices/#{slice}/action_spec.rb", t("action_spec.erb", context))
           # fs.write("spec/slices/#{slice}/view_spec.rb", t("view_spec.erb", context))
           # fs.write("spec/slices/#{slice}/repository_spec.rb", t("repository_spec.erb", context))
@@ -41,7 +46,7 @@ module Hanami
 
           ERB.new(
             File.read(__dir__ + "/slice/#{path}")
-          ).result(context.ctx)
+          ).result(context.instance_eval { binding })
         end
 
         alias_method :t, :template


### PR DESCRIPTION
We recently [removed Context files from Hanami::CLI](https://github.com/hanami/cli/pull/297/files) that this library was requiring, so CI started failing. This PR creates some temporary objects with ~Data.define objects~ Structs (since we need to support Ruby 3.1+) as placeholders. We'll do a proper refactor later, I just want to get CI green for now.