### PR TITLE
Remove check for versions less than Ruby 3.1

### DIFF
--- a/lib/hanami/rspec/generators/part.rb
+++ b/lib/hanami/rspec/generators/part.rb
@@ -22,14 +22,12 @@ module Hanami
             :camelized_app_name,
             :camelized_slice_name,
             :camelized_name,
-            :underscored_name,
-            :ruby_omit_hash_values?
+            :underscored_name
           ).new(
             inflector.camelize(app),
             slice ? inflector.camelize(slice) : nil,
             inflector.camelize(name),
-            inflector.underscore(name),
-            RUBY_VERSION >= "3.1"
+            inflector.underscore(name)
           )
 
           if slice

--- a/lib/hanami/rspec/generators/part/part_base_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_base_spec.erb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_app_name %>::Views::Part do
-<%- if ruby_omit_hash_values? -%>
   subject { described_class.new(value:) }
-<%- else -%>
-  subject { described_class.new(value: value) }
-<%- end -%>
   let(:value) { double("value") }
 
   it "works" do

--- a/lib/hanami/rspec/generators/part/part_slice_base_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_slice_base_spec.erb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_slice_name %>::Views::Part do
-<%- if ruby_omit_hash_values? -%>
   subject { described_class.new(value:) }
-<%- else -%>
-  subject { described_class.new(value: value) }
-<%- end -%>
   let(:value) { double("value") }
 
   it "works" do

--- a/lib/hanami/rspec/generators/part/part_slice_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_slice_spec.erb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_slice_name %>::Views::Parts::<%= camelized_name %> do
-<%- if ruby_omit_hash_values? -%>
   subject { described_class.new(value:) }
-<%- else -%>
-  subject { described_class.new(value: value) }
-<%- end -%>
   let(:value) { double("<%= underscored_name %>") }
 
   it "works" do

--- a/lib/hanami/rspec/generators/part/part_spec.erb
+++ b/lib/hanami/rspec/generators/part/part_spec.erb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe <%= camelized_app_name %>::Views::Parts::<%= camelized_name %> do
-<%- if ruby_omit_hash_values? -%>
   subject { described_class.new(value:) }
-<%- else -%>
-  subject { described_class.new(value: value) }
-<%- end -%>
   let(:value) { double("<%= underscored_name %>") }
 
   it "works" do

--- a/spec/unit/hanami/rspec/commands/generate/part_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/part_spec.rb
@@ -20,65 +20,33 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
           within_application_directory do
             subject.call({name: part_name})
 
-            if ruby_omit_hash_values?
-              base_part_spec = <<~EXPECTED
-                # frozen_string_literal: true
+            base_part_spec = <<~EXPECTED
+              # frozen_string_literal: true
 
-                RSpec.describe #{app_name}::Views::Part do
-                  subject { described_class.new(value:) }
-                  let(:value) { double("value") }
+              RSpec.describe #{app_name}::Views::Part do
+                subject { described_class.new(value:) }
+                let(:value) { double("value") }
 
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
                 end
-              EXPECTED
-              expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
+              end
+            EXPECTED
+            expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
 
-              part_spec = <<~EXPECTED
-                # frozen_string_literal: true
+            part_spec = <<~EXPECTED
+              # frozen_string_literal: true
 
-                RSpec.describe #{app_name}::Views::Parts::Client do
-                  subject { described_class.new(value:) }
-                  let(:value) { double("client") }
+              RSpec.describe #{app_name}::Views::Parts::Client do
+                subject { described_class.new(value:) }
+                let(:value) { double("client") }
 
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
                 end
-              EXPECTED
-              expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
-            end
-
-            unless ruby_omit_hash_values?
-              base_part_spec = <<~EXPECTED
-                # frozen_string_literal: true
-
-                RSpec.describe #{app_name}::Views::Part do
-                  subject { described_class.new(value: value) }
-                  let(:value) { double("value") }
-
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
-                end
-              EXPECTED
-              expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
-
-              part_spec = <<~EXPECTED
-                # frozen_string_literal: true
-
-                RSpec.describe #{app_name}::Views::Parts::Client do
-                  subject { described_class.new(value: value) }
-                  let(:value) { double("client") }
-
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
-                end
-              EXPECTED
-              expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
-            end
+              end
+            EXPECTED
+            expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
           end
         end
       end
@@ -90,35 +58,20 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
             subject.call({name: part_name})
 
-            if ruby_omit_hash_values?
-              <<~EXPECTED
-                # frozen_string_literal: true
+            part_spec = <<~EXPECTED
+              # frozen_string_literal: true
 
-                RSpec.describe #{app_name}::Views::Parts::Client do
-                  subject { described_class.new(value:) }
-                  let(:value) { double("client") }
+              RSpec.describe #{app_name}::Views::Parts::Client do
+                subject { described_class.new(value:) }
+                let(:value) { double("client") }
 
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
                 end
-              EXPECTED
-            else
-              part_spec = <<~EXPECTED
-                # frozen_string_literal: true
+              end
+            EXPECTED
 
-                RSpec.describe #{app_name}::Views::Parts::Client do
-                  subject { described_class.new(value: value) }
-                  let(:value) { double("client") }
-
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
-                end
-              EXPECTED
-
-              expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
-            end
+            expect(fs.read("spec/views/parts/client_spec.rb")).to eq(part_spec)
           end
         end
       end
@@ -143,93 +96,47 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
           within_application_directory do
             subject.call({slice: slice, name: part_name})
 
-            if ruby_omit_hash_values?
-              base_part_spec = <<~EXPECTED
-                # frozen_string_literal: true
+            base_part_spec = <<~EXPECTED
+              # frozen_string_literal: true
 
-                RSpec.describe #{app_name}::Views::Part do
-                  subject { described_class.new(value:) }
-                  let(:value) { double("value") }
+              RSpec.describe #{app_name}::Views::Part do
+                subject { described_class.new(value:) }
+                let(:value) { double("value") }
 
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
                 end
-              EXPECTED
-              expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
+              end
+            EXPECTED
+            expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
 
-              base_slice_part_spec = <<~EXPECTED
-                # frozen_string_literal: true
+            base_slice_part_spec = <<~EXPECTED
+              # frozen_string_literal: true
 
-                RSpec.describe #{slice_name}::Views::Part do
-                  subject { described_class.new(value:) }
-                  let(:value) { double("value") }
+              RSpec.describe #{slice_name}::Views::Part do
+                subject { described_class.new(value:) }
+                let(:value) { double("value") }
 
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
                 end
-              EXPECTED
-              expect(fs.read("spec/slices/#{slice}/views/part_spec.rb")).to eq(base_slice_part_spec)
+              end
+            EXPECTED
+            expect(fs.read("spec/slices/#{slice}/views/part_spec.rb")).to eq(base_slice_part_spec)
 
-              part_spec = <<~EXPECTED
-                # frozen_string_literal: true
+            part_spec = <<~EXPECTED
+              # frozen_string_literal: true
 
-                RSpec.describe #{slice_name}::Views::Parts::Client do
-                  subject { described_class.new(value:) }
-                  let(:value) { double("client") }
+              RSpec.describe #{slice_name}::Views::Parts::Client do
+                subject { described_class.new(value:) }
+                let(:value) { double("client") }
 
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
                 end
-              EXPECTED
-              expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
-            end
-
-            unless ruby_omit_hash_values?
-              base_part_spec = <<~EXPECTED
-                # frozen_string_literal: true
-
-                RSpec.describe #{app_name}::Views::Part do
-                  subject { described_class.new(value: value) }
-                  let(:value) { double("value") }
-
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
-                end
-              EXPECTED
-              expect(fs.read("spec/views/part_spec.rb")).to eq(base_part_spec)
-
-              base_slice_part_spec = <<~EXPECTED
-                # frozen_string_literal: true
-
-                RSpec.describe #{slice_name}::Views::Part do
-                  subject { described_class.new(value: value) }
-                  let(:value) { double("value") }
-
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
-                end
-              EXPECTED
-              expect(fs.read("spec/slices/#{slice}/views/part_spec.rb")).to eq(base_slice_part_spec)
-
-              part_spec = <<~EXPECTED
-                # frozen_string_literal: true
-
-                RSpec.describe #{slice_name}::Views::Parts::Client do
-                  subject { described_class.new(value: value) }
-                  let(:value) { double("client") }
-
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
-                end
-              EXPECTED
-              expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
-            end
+              end
+            EXPECTED
+            expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
           end
         end
       end
@@ -242,33 +149,18 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
             subject.call({slice: slice, name: part_name})
 
-            if ruby_omit_hash_values?
-              part_spec = <<~EXPECTED
-                # frozen_string_literal: true
+            part_spec = <<~EXPECTED
+              # frozen_string_literal: true
 
-                RSpec.describe #{slice_name}::Views::Parts::Client do
-                  subject { described_class.new(value:) }
-                  let(:value) { double("client") }
+              RSpec.describe #{slice_name}::Views::Parts::Client do
+                subject { described_class.new(value:) }
+                let(:value) { double("client") }
 
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
+                it "works" do
+                  expect(subject).to be_kind_of(described_class)
                 end
-              EXPECTED
-            else
-              part_spec = <<~EXPECTED
-                # frozen_string_literal: true
-
-                RSpec.describe #{slice_name}::Views::Parts::Client do
-                  subject { described_class.new(value: value) }
-                  let(:value) { double("client") }
-
-                  it "works" do
-                    expect(subject).to be_kind_of(described_class)
-                  end
-                end
-              EXPECTED
-            end
+              end
+            EXPECTED
             expect(fs.read("spec/slices/#{slice}/views/parts/client_spec.rb")).to eq(part_spec)
           end
         end
@@ -322,9 +214,5 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
       yield
     end
-  end
-
-  def ruby_omit_hash_values?
-    RUBY_VERSION >= "3.1"
   end
 end


### PR DESCRIPTION
Since we don't support EOL ruby versions: https://www.ruby-lang.org/en/downloads/branches/