### PR TITLE
Fix `support_request` template

### DIFF
--- a/lib/hanami/rspec/generators/support_requests.rb
+++ b/lib/hanami/rspec/generators/support_requests.rb
@@ -2,12 +2,12 @@
 
 require "rack/test"
 
-RSpec.shared_context "Rack::Test" do
+RSpec.shared_context "with Rack::Test" do
   # Define the app for Rack::Test requests
   let(:app) { Hanami.app }
 end
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods, type: :request
-  config.include_context "Rack::Test", type: :request
+  config.include_context "with Rack::Test", type: :request
 end

--- a/spec/unit/hanami/rspec/commands/install_spec.rb
+++ b/spec/unit/hanami/rspec/commands/install_spec.rb
@@ -220,14 +220,14 @@ RSpec.describe Hanami::RSpec::Commands::Install do
 
         require "rack/test"
 
-        RSpec.shared_context "Rack::Test" do
+        RSpec.shared_context "with Rack::Test" do
           # Define the app for Rack::Test requests
           let(:app) { Hanami.app }
         end
 
         RSpec.configure do |config|
           config.include Rack::Test::Methods, type: :request
-          config.include_context "Rack::Test", type: :request
+          config.include_context "with Rack::Test", type: :request
         end
       EOF
       expect(fs.read("spec/support/requests.rb")).to eq(support_requests)


### PR DESCRIPTION
Currently the rspec generator will generate a support file with a shared context named simply "Rack::Test".  This context name is in violation of rubocop's [RSpec/ContextWording cop](https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspeccontextwording). This introduces a fix to bring that support file into compliance with the rubocop cop.