### PR TITLE
Update callbacks to support dry-cli 1.3 and 1.4+

### DIFF
--- a/lib/hanami/rspec/commands.rb
+++ b/lib/hanami/rspec/commands.rb
@@ -114,9 +114,20 @@ module Hanami
         # @since 2.0.0
         # @api private
         class Slice < Hanami::CLI::Command
-          # FIXME: dry-cli kwargs aren't correctly forwarded in Ruby 3
-          def call(options, **)
-            slice = inflector.underscore(Shellwords.shellescape(options[:name]))
+          # @since 2.0.0
+          # @api private
+          def call(options = nil, name: nil, **)
+            # Support multiple calling conventions for dry-cli cross-version compatibility:
+            #
+            # - dry-cli 1.3 calls with positional hash: call({name: "foo"})
+            # - dry-cli 1.4+: calls with keyword arguments: call(name: "foo")
+            #
+            # TODO: Remove this with Hanami 2.4 (which will require dry-cli 1.4+).
+            if options.is_a?(Hash)
+              name = options[:name]
+            end
+
+            slice = inflector.underscore(Shellwords.shellescape(name))
 
             generator = Generators::Slice.new(fs: fs, inflector: inflector)
             generator.call(slice)
@@ -128,13 +139,23 @@ module Hanami
         class Action < Hanami::CLI::Commands::App::Command
           # @since 2.0.0
           # @api private
-          def call(options, **)
-            # FIXME: dry-cli kwargs aren't correctly forwarded in Ruby 3
+          def call(options = nil, name: nil, slice: nil, skip_tests: false, **)
+            # Support multiple calling conventions for dry-cli cross-version compatibility:
+            #
+            # - dry-cli 1.3 calls with positional hash: call({name: "foo"})
+            # - dry-cli 1.4+: calls with keyword arguments: call(name: "foo")
+            #
+            # TODO: Remove this with Hanami 2.4 (which will require dry-cli 1.4+).
+            if options.is_a?(Hash)
+              name = options[:name]
+              slice = options[:slice]
+              skip_tests = options[:skip_tests] || false
+            end
 
-            return if options[:skip_tests]
+            return if skip_tests
 
-            slice = inflector.underscore(Shellwords.shellescape(options[:slice])) if options[:slice]
-            key = inflector.underscore(Shellwords.shellescape(options[:name]))
+            slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
+            key = inflector.underscore(Shellwords.shellescape(name))
 
             namespace = slice ? inflector.camelize(slice) : app.namespace
             base_path = slice ? "spec/slices/#{slice}" : "spec"
@@ -149,13 +170,23 @@ module Hanami
         class Part < Hanami::CLI::Commands::App::Command
           # @since 2.1.0
           # @api private
-          def call(options, **)
-            # FIXME: dry-cli kwargs aren't correctly forwarded in Ruby 3
+          def call(options = nil, name: nil, slice: nil, skip_tests: false, **)
+            # Support multiple calling conventions for dry-cli cross-version compatibility:
+            #
+            # - dry-cli 1.3 calls with positional hash: call({name: "foo"})
+            # - dry-cli 1.4+: calls with keyword arguments: call(name: "foo")
+            #
+            # TODO: Remove this with Hanami 2.4 (which will require dry-cli 1.4+).
+            if options.is_a?(Hash)
+              name = options[:name]
+              slice = options[:slice]
+              skip_tests = options[:skip_tests] || false
+            end
 
-            return if options[:skip_tests]
+            return if skip_tests
 
-            slice = inflector.underscore(Shellwords.shellescape(options[:slice])) if options[:slice]
-            name = inflector.underscore(Shellwords.shellescape(options[:name]))
+            slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
+            name = inflector.underscore(Shellwords.shellescape(name))
 
             generator = Generators::Part.new(fs: fs, inflector: inflector)
             generator.call(app.namespace, slice, name)

--- a/spec/unit/hanami/rspec/commands/generate/action_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/action_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
     context "app" do
       it "generates spec file" do
         within_application_directory do
-          subject.call({name: action_name})
+          subject.call(name: action_name)
 
           action_spec = <<~EXPECTED
             # frozen_string_literal: true
@@ -39,7 +39,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
 
         it "generates spec file" do
           within_application_directory do
-            subject.call({name: action_name})
+            subject.call(name: action_name)
 
             # spec/<slice>/action_spec.rb
             action_spec = <<~EXPECTED
@@ -62,7 +62,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
       context "skip_tests given" do
         it "does not generate a spec file" do
           within_application_directory do
-            subject.call({name: action_name, skip_tests: true})
+            subject.call(name: action_name, skip_tests: true)
 
             expect(fs.exist?("spec/actions/client/create_spec.rb")).to be false
           end
@@ -76,7 +76,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
 
       it "generates spec file" do
         within_application_directory do
-          subject.call({slice: slice, name: action_name})
+          subject.call(slice: slice, name: action_name)
 
           action_spec = <<~EXPECTED
             # frozen_string_literal: true
@@ -97,7 +97,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
       context "skip_tests given" do
         it "does not generate a spec file" do
           within_application_directory do
-            subject.call({slice: slice, name: action_name, skip_tests: true})
+            subject.call(slice: slice, name: action_name, skip_tests: true)
 
             expect(fs.exist?("spec/slices/#{slice}/actions/client/create_spec.rb")).to be false
           end

--- a/spec/unit/hanami/rspec/commands/generate/part_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/part_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
       context "without base part" do
         it "generates spec file" do
           within_application_directory do
-            subject.call({name: part_name})
+            subject.call(name: part_name)
 
             base_part_spec = <<~EXPECTED
               # frozen_string_literal: true
@@ -55,7 +55,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
           within_application_directory do
             fs.touch("spec/views/part_spec.rb")
 
-            subject.call({name: part_name})
+            subject.call(name: part_name)
 
             part_spec = <<~EXPECTED
               # frozen_string_literal: true
@@ -78,7 +78,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
       context "skip_tests given" do
         it "does not generate spec file" do
           within_application_directory do
-            subject.call({name: part_name, skip_tests: true})
+            subject.call(name: part_name, skip_tests: true)
 
             expect(fs.exist?("spec/views/parts/client_spec.rb")).to be false
           end
@@ -93,7 +93,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
       context "without base part" do
         it "generates spec file" do
           within_application_directory do
-            subject.call({slice: slice, name: part_name})
+            subject.call(slice: slice, name: part_name)
 
             base_part_spec = <<~EXPECTED
               # frozen_string_literal: true
@@ -146,7 +146,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
             fs.touch("spec/views/part_spec.rb")
             fs.touch("spec/slices/#{slice}/views/part_spec.rb")
 
-            subject.call({slice: slice, name: part_name})
+            subject.call(slice: slice, name: part_name)
 
             part_spec = <<~EXPECTED
               # frozen_string_literal: true
@@ -168,7 +168,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
       context "skip_tests given" do
         it "does not generate spec file" do
           within_application_directory do
-            subject.call({slice: slice, name: part_name, skip_tests: true})
+            subject.call(slice: slice, name: part_name, skip_tests: true)
 
             expect(fs.exist?("spec/slices/#{slice}/views/parts/client_spec.rb")).to be false
           end

--- a/spec/unit/hanami/rspec/commands/generate/slice_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/slice_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Slice do
     let(:slice) { "main" }
 
     it "generates spec files" do
-      subject.call({name: slice})
+      subject.call(name: slice)
 
       # spec/<slice>/action_spec.rb
       action_spec = <<~EXPECTED


### PR DESCRIPTION
dry-cli 1.3 had a bug where the keyword args were passed as a single positional options hash. Our code here was set up to expect this. dry-cli 1.4 no longer does this, passing real keyword arguments instead. Now we check for both, allowing the hanami-rspec CLI callbacks to continue to work.