### PR TITLE
Fix hanami-action gem name, since it's been renamed

### DIFF
--- a/lib/hanami/rspec.rb
+++ b/lib/hanami/rspec.rb
@@ -35,7 +35,7 @@ module Hanami
       Hanami::CLI.before "install", Commands::Install
       Hanami::CLI.after "generate slice", Commands::Generate::Slice
 
-      if Hanami.bundled?("hanami-controller")
+      if Hanami.bundled?("hanami-action")
         Hanami::CLI.after "generate action", Commands::Generate::Action
       end
 


### PR DESCRIPTION
See: https://github.com/hanami/hanami-action/pull/507