### PR TITLE
Use `prepend_before` for DatabaseCleaner hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Changed
 
+- Use `prepend_before` for the generated DatabaseCleaner `:db` hook, so it runs before any other `before` hooks that might touch the database. This prevents factory calls in spec-level `before` blocks from running before the test transaction starts and leaking records across tests. (@timriley in #47)
+
 ### Deprecated
 
 ### Removed

--- a/lib/hanami/rspec/generators/support_db_cleaning.rb
+++ b/lib/hanami/rspec/generators/support_db_cleaning.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.before :each, :db do |example|
+  config.prepend_before :each, :db do |example|
     strategy = example.metadata[:js] ? :truncation : :transaction
 
     all_databases.call.each do |db|

--- a/spec/unit/hanami/rspec/commands/install_spec.rb
+++ b/spec/unit/hanami/rspec/commands/install_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Hanami::RSpec::Commands::Install do
             end
           end
 
-          config.before :each, :db do |example|
+          config.prepend_before :each, :db do |example|
             strategy = example.metadata[:js] ? :truncation : :transaction
 
             all_databases.call.each do |db|


### PR DESCRIPTION
This ensure it runs before any other `before` hooks that might touch the database, which prevents e.g. factory calls in spec-level `before` blocks from running before the test transaction starts and leaking records across tests.

Fixes #45