### PR TITLE
Generate specs for operations and mailers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,15 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Security
 
-[Unreleased]: https://github.com/hanami/rspec/compare/v2.3.1...HEAD
+[Unreleased]: https://github.com/hanami/rspec/compare/v3.0.0.rc1...HEAD
 
 ## [v3.0.0.rc1]
+
+### Added
+
+- Activate Dry Monads' RSpec extension in `spec/support/operations.rb`. (@timriley)
+- Generate a starter spec when running `hanami generate operation`. (@timriley)
+- Generate a starter spec when running `hanami generate mailer`. (@timriley)
 
 ### Changed
 

--- a/lib/hanami/rspec.rb
+++ b/lib/hanami/rspec.rb
@@ -35,12 +35,20 @@ module Hanami
       Hanami::CLI.before "install", Commands::Install
       Hanami::CLI.after "generate slice", Commands::Generate::Slice
 
+      if Hanami.bundled?("dry-operation")
+        Hanami::CLI.after "generate operation", Commands::Generate::Operation
+      end
+
       if Hanami.bundled?("hanami-action")
         Hanami::CLI.after "generate action", Commands::Generate::Action
       end
 
       if Hanami.bundled?("hanami-view")
         Hanami::CLI.after "generate part", Commands::Generate::Part
+      end
+
+      if Hanami.bundled?("hanami-mailer")
+        Hanami::CLI.after "generate mailer", Commands::Generate::Mailer
       end
     end
   end

--- a/lib/hanami/rspec/commands.rb
+++ b/lib/hanami/rspec/commands.rb
@@ -4,14 +4,9 @@ require "shellwords"
 
 module Hanami
   module RSpec
-    # @since 2.0.0
     # @api private
     module Commands
-      # @since 2.0.0
-      # @api private
       class Install < Hanami::CLI::Command
-        # @since 2.0.0
-        # @api private
         def call(*, **)
           append_gemfile
           append_gitignore
@@ -108,14 +103,8 @@ module Hanami
         end
       end
 
-      # @since 2.0.0
-      # @api private
       module Generate
-        # @since 2.0.0
-        # @api private
         class Slice < Hanami::CLI::Command
-          # @since 2.0.0
-          # @api private
           def call(name: nil, **)
             slice = inflector.underscore(Shellwords.shellescape(name))
 
@@ -124,11 +113,7 @@ module Hanami
           end
         end
 
-        # @since 2.0.0
-        # @api private
         class Action < Hanami::CLI::Commands::App::Command
-          # @since 2.0.0
-          # @api private
           def call(name: nil, slice: nil, skip_tests: false, **)
             return if skip_tests
 
@@ -143,11 +128,7 @@ module Hanami
           end
         end
 
-        # @since 2.1.0
-        # @api private
         class Part < Hanami::CLI::Commands::App::Command
-          # @since 2.1.0
-          # @api private
           def call(name: nil, slice: nil, skip_tests: false, **)
             return if skip_tests
 
@@ -156,6 +137,36 @@ module Hanami
 
             generator = Generators::Part.new(fs: fs, inflector: inflector)
             generator.call(app.namespace, slice, name)
+          end
+        end
+
+        class Operation < Hanami::CLI::Commands::App::Command
+          def call(name: nil, slice: nil, skip_tests: false, **)
+            return if skip_tests
+
+            slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
+            key = inflector.underscore(Shellwords.shellescape(name))
+
+            namespace = slice ? inflector.camelize(slice) : app.namespace
+            base_path = slice ? "spec/slices/#{slice}" : "spec"
+
+            generator = Generators::Operation.new(fs:, inflector:)
+            generator.call(key:, namespace:, base_path:)
+          end
+        end
+
+        class Mailer < Hanami::CLI::Commands::App::Command
+          def call(name: nil, slice: nil, skip_tests: false, **)
+            return if skip_tests
+
+            slice = inflector.underscore(Shellwords.shellescape(slice)) if slice
+            key = inflector.underscore(Shellwords.shellescape(name))
+
+            namespace = slice ? inflector.camelize(slice) : app.namespace
+            base_path = slice ? "spec/slices/#{slice}" : "spec"
+
+            generator = Generators::Mailer.new(fs:, inflector:)
+            generator.call(key:, namespace:, base_path:)
           end
         end
       end

--- a/lib/hanami/rspec/generators/mailer.rb
+++ b/lib/hanami/rspec/generators/mailer.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "hanami/cli/generators/app/ruby_class_file"
+
+module Hanami
+  module RSpec
+    module Generators
+      # @api private
+      class Mailer
+        attr_reader :fs, :inflector
+
+        def initialize(fs:, inflector:)
+          @fs = fs
+          @inflector = inflector
+        end
+
+        def call(key:, namespace:, base_path:)
+          mailer_class_file = mailer_class_file(key:, namespace:, base_path:)
+          spec_file_path = mailer_class_file.path.gsub(/\.rb$/, "_spec.rb")
+          mailer_class_name = mailer_class_file.fully_qualified_name
+
+          fs.write(spec_file_path, spec_content(mailer_class_name))
+        end
+
+        private
+
+        def mailer_class_file(key:, namespace:, base_path:)
+          Hanami::CLI::Generators::App::RubyClassFile.new(
+            fs:, inflector:, namespace:,
+            key: inflector.underscore(key),
+            base_path: base_path,
+            extra_namespace: "Mailers"
+          )
+        end
+
+        def spec_content(class_name)
+          <<~RUBY
+            # frozen_string_literal: true
+
+            RSpec.describe #{class_name} do
+              subject(:mailer) { described_class.new }
+
+              # Inspect the delivered message to set expectations on its contents:
+              #
+              # expect(result.message.to).to eq(["recipient@example.com"])
+              # expect(result.message.subject).to eq("Welcome")
+              # expect(result.message.html_body).to include("...")
+
+              xit "delivers" do
+                result = mailer.deliver
+
+                expect(result).to be_success
+              end
+            end
+          RUBY
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/rspec/generators/operation.rb
+++ b/lib/hanami/rspec/generators/operation.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "hanami/cli/generators/app/ruby_class_file"
+
+module Hanami
+  module RSpec
+    module Generators
+      # @api private
+      class Operation
+        attr_reader :fs, :inflector
+
+        def initialize(fs:, inflector:)
+          @fs = fs
+          @inflector = inflector
+        end
+
+        def call(key:, namespace:, base_path:)
+          operation_class_file = operation_class_file(key:, namespace:, base_path:)
+          spec_file_path = operation_class_file.path.gsub(/\.rb$/, "_spec.rb")
+          operation_class_name = operation_class_file.fully_qualified_name
+
+          fs.write(spec_file_path, spec_content(operation_class_name))
+        end
+
+        private
+
+        def operation_class_file(key:, namespace:, base_path:)
+          Hanami::CLI::Generators::App::RubyClassFile.new(
+            fs:, inflector:, namespace:,
+            key: inflector.underscore(key),
+            base_path: base_path
+          )
+        end
+
+        def spec_content(class_name)
+          <<~RUBY
+            # frozen_string_literal: true
+
+            RSpec.describe #{class_name} do
+              subject(:operation) { described_class.new }
+
+              # Use `be_success` and `be_failure` (from spec/support/operations.rb) to set expectations on an
+              # operation's result:
+              #
+              # expect(result).to be_success(expected_value)
+              # expect(result).to be_failure(:some_error)
+
+              xit "succeeds" do
+                result = operation.call
+
+                expect(result).to be_success
+              end
+            end
+          RUBY
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/rspec/generators/support_operations.rb
+++ b/lib/hanami/rspec/generators/support_operations.rb
@@ -2,7 +2,8 @@
 
 require "dry/monads"
 
-RSpec.configure do |config|
-  # Provide `Success` and `Failure` for testing operation results
-  config.include Dry::Monads[:result]
-end
+# Load Dry Monads' RSpec extension.
+#
+# This provides `be_success` and `be_failure` matchers for operation results, along with `Success`
+# and `Failure` constructors for use within your examples.
+Dry::Monads.load_extensions(:rspec)

--- a/spec/unit/hanami/rspec/commands/generate/action_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/action_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
 
     context "app" do
       it "generates spec file" do
-        within_application_directory do
+        within_app_dir do
           subject.call(name: action_name)
 
           action_spec = <<~EXPECTED
@@ -38,7 +38,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
         let(:action_name) { "reporting.annual.billing.index" }
 
         it "generates spec file" do
-          within_application_directory do
+          within_app_dir do
             subject.call(name: action_name)
 
             # spec/<slice>/action_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
 
       context "skip_tests given" do
         it "does not generate a spec file" do
-          within_application_directory do
+          within_app_dir do
             subject.call(name: action_name, skip_tests: true)
 
             expect(fs.exist?("spec/actions/client/create_spec.rb")).to be false
@@ -75,7 +75,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
       let(:slice_name) { "Main" }
 
       it "generates spec file" do
-        within_application_directory do
+        within_app_dir do
           subject.call(slice: slice, name: action_name)
 
           action_spec = <<~EXPECTED
@@ -93,22 +93,12 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Action do
           expect(fs.read("spec/slices/#{slice}/actions/client/create_spec.rb")).to eq(action_spec)
         end
       end
-
-      context "skip_tests given" do
-        it "does not generate a spec file" do
-          within_application_directory do
-            subject.call(slice: slice, name: action_name, skip_tests: true)
-
-            expect(fs.exist?("spec/slices/#{slice}/actions/client/create_spec.rb")).to be false
-          end
-        end
-      end
     end
   end
 
   private
 
-  def within_application_directory(app: app_name)
+  def within_app_dir(app: app_name)
     dir = fs.join(TMP, SecureRandom.uuid, app)
 
     fs.mkdir(dir)

--- a/spec/unit/hanami/rspec/commands/generate/mailer_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/mailer_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "securerandom"
+
+RSpec.describe Hanami::RSpec::Commands::Generate::Mailer do
+  describe "#call" do
+    subject { described_class.new(fs: fs) }
+
+    let(:fs) { Dry::Files.new }
+
+    let(:app_name) { "Bookshelf" }
+
+    let(:mailer_name) { "welcome" }
+
+    context "app" do
+      it "generates spec file" do
+        within_app_dir do
+          subject.call(name: mailer_name)
+
+          mailer_spec = <<~EXPECTED
+            # frozen_string_literal: true
+
+            RSpec.describe #{app_name}::Mailers::Welcome do
+              subject(:mailer) { described_class.new }
+
+              # Inspect the delivered message to set expectations on its contents:
+              #
+              # expect(result.message.to).to eq(["recipient@example.com"])
+              # expect(result.message.subject).to eq("Welcome")
+              # expect(result.message.html_body).to include("...")
+
+              xit "delivers" do
+                result = mailer.deliver
+
+                expect(result).to be_success
+              end
+            end
+          EXPECTED
+          expect(fs.read("spec/mailers/welcome_spec.rb")).to eq(mailer_spec)
+        end
+      end
+
+      context "with nested mailer name" do
+        let(:mailer_name) { "notifications.welcome" }
+
+        it "generates spec file" do
+          within_app_dir do
+            subject.call(name: mailer_name)
+
+            expect(fs.read("spec/mailers/notifications/welcome_spec.rb"))
+              .to include("RSpec.describe #{app_name}::Mailers::Notifications::Welcome do")
+          end
+        end
+      end
+
+      context "skip_tests given" do
+        it "does not generate a spec file" do
+          within_app_dir do
+            subject.call(name: mailer_name, skip_tests: true)
+
+            expect(fs.exist?("spec/mailers/welcome_spec.rb")).to be false
+          end
+        end
+      end
+    end
+
+    context "slice" do
+      let(:slice) { "main" }
+      let(:slice_name) { "Main" }
+
+      it "generates spec file" do
+        within_app_dir do
+          subject.call(slice: slice, name: mailer_name)
+
+          expect(fs.read("spec/slices/#{slice}/mailers/welcome_spec.rb"))
+            .to include("RSpec.describe #{slice_name}::Mailers::Welcome do")
+        end
+      end
+    end
+  end
+
+  private
+
+  def within_app_dir(app: app_name)
+    dir = fs.join(TMP, SecureRandom.uuid, app)
+
+    fs.mkdir(dir)
+    fs.chdir(dir) do
+      app_code = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami"
+
+        module #{app}
+          class App < Hanami::App
+          end
+        end
+      CODE
+      fs.write("config/app.rb", app_code)
+
+      routes = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami/routes"
+
+        module #{app}
+          class Routes < Hanami::Routes
+            define do
+              root { "Hello from Hanami" }
+            end
+          end
+        end
+      CODE
+      fs.write("config/routes.rb", routes)
+
+      yield
+    end
+  end
+end

--- a/spec/unit/hanami/rspec/commands/generate/operation_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/operation_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "securerandom"
+
+RSpec.describe Hanami::RSpec::Commands::Generate::Operation do
+  describe "#call" do
+    subject { described_class.new(fs: fs) }
+
+    let(:fs) { Dry::Files.new }
+
+    let(:app_name) { "Bookshelf" }
+
+    let(:operation_name) { "books.add" }
+
+    context "app" do
+      it "generates spec file" do
+        within_app_dir do
+          subject.call(name: operation_name)
+
+          operation_spec = <<~EXPECTED
+            # frozen_string_literal: true
+
+            RSpec.describe #{app_name}::Books::Add do
+              subject(:operation) { described_class.new }
+
+              # Use `be_success` and `be_failure` (from spec/support/operations.rb) to set expectations on an
+              # operation's result:
+              #
+              # expect(result).to be_success(expected_value)
+              # expect(result).to be_failure(:some_error)
+
+              xit "succeeds" do
+                result = operation.call
+
+                expect(result).to be_success
+              end
+            end
+          EXPECTED
+          expect(fs.read("spec/books/add_spec.rb")).to eq(operation_spec)
+        end
+      end
+
+      context "top-level operation name" do
+        let(:operation_name) { "add" }
+
+        it "generates spec file" do
+          within_app_dir do
+            subject.call(name: operation_name)
+
+            expect(fs.read("spec/add_spec.rb")).to include("RSpec.describe #{app_name}::Add do")
+          end
+        end
+      end
+
+      context "skip_tests given" do
+        it "does not generate a spec file" do
+          within_app_dir do
+            subject.call(name: operation_name, skip_tests: true)
+
+            expect(fs.exist?("spec/books/add_spec.rb")).to be false
+          end
+        end
+      end
+    end
+
+    context "slice" do
+      let(:slice) { "main" }
+      let(:slice_name) { "Main" }
+
+      it "generates spec file" do
+        within_app_dir do
+          subject.call(slice: slice, name: operation_name)
+
+          expect(fs.read("spec/slices/#{slice}/books/add_spec.rb"))
+            .to include("RSpec.describe #{slice_name}::Books::Add do")
+        end
+      end
+    end
+  end
+
+  private
+
+  def within_app_dir(app: app_name)
+    dir = fs.join(TMP, SecureRandom.uuid, app)
+
+    fs.mkdir(dir)
+    fs.chdir(dir) do
+      app_code = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami"
+
+        module #{app}
+          class App < Hanami::App
+          end
+        end
+      CODE
+      fs.write("config/app.rb", app_code)
+
+      routes = <<~CODE
+        # frozen_string_literal: true
+
+        require "hanami/routes"
+
+        module #{app}
+          class Routes < Hanami::Routes
+            define do
+              root { "Hello from Hanami" }
+            end
+          end
+        end
+      CODE
+      fs.write("config/routes.rb", routes)
+
+      yield
+    end
+  end
+end

--- a/spec/unit/hanami/rspec/commands/generate/part_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/part_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
     context "app" do
       context "without base part" do
         it "generates spec file" do
-          within_application_directory do
+          within_app_dir do
             subject.call(name: part_name)
 
             base_part_spec = <<~EXPECTED
@@ -52,7 +52,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
       context "with base part" do
         it "generates spec file" do
-          within_application_directory do
+          within_app_dir do
             fs.touch("spec/views/part_spec.rb")
 
             subject.call(name: part_name)
@@ -77,7 +77,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
       context "skip_tests given" do
         it "does not generate spec file" do
-          within_application_directory do
+          within_app_dir do
             subject.call(name: part_name, skip_tests: true)
 
             expect(fs.exist?("spec/views/parts/client_spec.rb")).to be false
@@ -92,7 +92,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
       context "without base part" do
         it "generates spec file" do
-          within_application_directory do
+          within_app_dir do
             subject.call(slice: slice, name: part_name)
 
             base_part_spec = <<~EXPECTED
@@ -142,7 +142,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
       context "with base part" do
         it "generates spec file" do
-          within_application_directory do
+          within_app_dir do
             fs.touch("spec/views/part_spec.rb")
             fs.touch("spec/slices/#{slice}/views/part_spec.rb")
 
@@ -167,7 +167,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
       context "skip_tests given" do
         it "does not generate spec file" do
-          within_application_directory do
+          within_app_dir do
             subject.call(slice: slice, name: part_name, skip_tests: true)
 
             expect(fs.exist?("spec/slices/#{slice}/views/parts/client_spec.rb")).to be false
@@ -179,7 +179,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Part do
 
   private
 
-  def within_application_directory(app: app_name)
+  def within_app_dir(app: app_name)
     dir = fs.join(TMP, SecureRandom.uuid, app)
 
     fs.mkdir(dir)

--- a/spec/unit/hanami/rspec/commands/install_spec.rb
+++ b/spec/unit/hanami/rspec/commands/install_spec.rb
@@ -207,10 +207,11 @@ RSpec.describe Hanami::RSpec::Commands::Install do
 
         require "dry/monads"
 
-        RSpec.configure do |config|
-          # Provide `Success` and `Failure` for testing operation results
-          config.include Dry::Monads[:result]
-        end
+        # Load Dry Monads' RSpec extension.
+        #
+        # This provides `be_success` and `be_failure` matchers for operation results, along with `Success`
+        # and `Failure` constructors for use within your examples.
+        Dry::Monads.load_extensions(:rspec)
       EOF
       expect(fs.read("spec/support/operations.rb")).to eq(support_operations)
 


### PR DESCRIPTION
And use Dry Monads’ RSpec extension to provide fuller support for testing against Result objects.