### PR TITLE
Generate spec/support/mailers.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Added
 
+- Generate `spec/support/mailers.rb` to reset recorded mail deliveries between examples tagged `:mailers`. Use this tag for the generated mailer tests. (@timriley in #49)
+
 ### Changed
 
 ### Deprecated

--- a/lib/hanami/rspec/commands.rb
+++ b/lib/hanami/rspec/commands.rb
@@ -16,6 +16,7 @@ module Hanami
           copy_support_db
           copy_support_features
           copy_support_operations
+          copy_support_mailers
           copy_support_requests
 
           generate_request_spec
@@ -85,6 +86,15 @@ module Hanami
           fs.cp(
             fs.expand_path(fs.join("generators", "support_operations.rb"), __dir__),
             fs.expand_path(fs.join("spec", "support", "operations.rb"))
+          )
+        end
+
+        def copy_support_mailers
+          return unless Hanami.bundled?("hanami-mailer")
+
+          fs.cp(
+            fs.expand_path(fs.join("generators", "support_mailers.rb"), __dir__),
+            fs.expand_path(fs.join("spec", "support", "mailers.rb"))
           )
         end
 

--- a/lib/hanami/rspec/generators/mailer.rb
+++ b/lib/hanami/rspec/generators/mailer.rb
@@ -37,7 +37,7 @@ module Hanami
           <<~RUBY
             # frozen_string_literal: true
 
-            RSpec.describe #{class_name} do
+            RSpec.describe #{class_name}, :mailers do
               subject(:mailer) { described_class.new }
 
               # Inspect the delivered message to set expectations on its contents:

--- a/lib/hanami/rspec/generators/support_mailers.rb
+++ b/lib/hanami/rspec/generators/support_mailers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Reset recorded mail deliveries between examples tagged `:mailers`
+#
+# In the test env, mail is delivered via a shared test delivery method, so recorded deliveries
+# accumulate across examples. Tag any example that sends mail with `:mailers` to start with a clean
+# slate:
+#
+#   RSpec.describe Mailers::Welcome, :mailers do
+#     # ...
+#   end
+RSpec.configure do |config|
+  config.prepend_before :each, :mailers do
+    Hanami.app.with_slices.each do |slice|
+      next unless slice.key?("mailers.delivery_method")
+
+      slice["mailers.delivery_method"].clear
+    end
+  end
+end

--- a/spec/unit/hanami/rspec/commands/generate/mailer_spec.rb
+++ b/spec/unit/hanami/rspec/commands/generate/mailer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Mailer do
           mailer_spec = <<~EXPECTED
             # frozen_string_literal: true
 
-            RSpec.describe #{app_name}::Mailers::Welcome do
+            RSpec.describe #{app_name}::Mailers::Welcome, :mailers do
               subject(:mailer) { described_class.new }
 
               # Inspect the delivered message to set expectations on its contents:
@@ -49,7 +49,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Mailer do
             subject.call(name: mailer_name)
 
             expect(fs.read("spec/mailers/notifications/welcome_spec.rb"))
-              .to include("RSpec.describe #{app_name}::Mailers::Notifications::Welcome do")
+              .to include("RSpec.describe #{app_name}::Mailers::Notifications::Welcome, :mailers do")
           end
         end
       end
@@ -74,7 +74,7 @@ RSpec.describe Hanami::RSpec::Commands::Generate::Mailer do
           subject.call(slice: slice, name: mailer_name)
 
           expect(fs.read("spec/slices/#{slice}/mailers/welcome_spec.rb"))
-            .to include("RSpec.describe #{slice_name}::Mailers::Welcome do")
+            .to include("RSpec.describe #{slice_name}::Mailers::Welcome, :mailers do")
         end
       end
     end

--- a/spec/unit/hanami/rspec/commands/install_spec.rb
+++ b/spec/unit/hanami/rspec/commands/install_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Hanami::RSpec::Commands::Install do
     before do
       allow(Hanami).to receive(:bundled?).and_call_original
       allow(Hanami).to receive(:bundled?).with("hanami-db").and_return true
+      allow(Hanami).to receive(:bundled?).with("hanami-mailer").and_return true
     end
 
     around do |example|
@@ -215,6 +216,31 @@ RSpec.describe Hanami::RSpec::Commands::Install do
       EOF
       expect(fs.read("spec/support/operations.rb")).to eq(support_operations)
 
+      # spec/support/mailers.rb
+      support_mailers = <<~EOF
+        # frozen_string_literal: true
+
+        # Reset recorded mail deliveries between examples tagged `:mailers`
+        #
+        # In the test env, mail is delivered via a shared test delivery method, so recorded deliveries
+        # accumulate across examples. Tag any example that sends mail with `:mailers` to start with a clean
+        # slate:
+        #
+        #   RSpec.describe Mailers::Welcome, :mailers do
+        #     # ...
+        #   end
+        RSpec.configure do |config|
+          config.prepend_before :each, :mailers do
+            Hanami.app.with_slices.each do |slice|
+              next unless slice.key?("mailers.delivery_method")
+
+              slice["mailers.delivery_method"].clear
+            end
+          end
+        end
+      EOF
+      expect(fs.read("spec/support/mailers.rb")).to eq(support_mailers)
+
       # spec/support/requests.rb
       support_requests = <<~EOF
         # frozen_string_literal: true
@@ -274,6 +300,18 @@ RSpec.describe Hanami::RSpec::Commands::Install do
 
         expect(fs.exist?("spec/support/db.rb")).to be false
         expect(fs.exist?("spec/support/db/cleaning.rb")).to be false
+      end
+    end
+
+    context "hanami-mailer not bundled" do
+      before do
+        allow(Hanami).to receive(:bundled?).with("hanami-mailer").and_return false
+      end
+
+      it "does not add the mailers spec support file" do
+        subject.call(arbitrary_argument)
+
+        expect(fs.exist?("spec/support/mailers.rb")).to be false
       end
     end
   end


### PR DESCRIPTION
This resets mail deliveries between examples tagged with `:mailers`.